### PR TITLE
feat: add GitHub Copilot CLI support via provider abstraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@github/copilot-sdk": "^0.1.0",
         "@opencode-ai/sdk": "^1.2.10",
         "chalk": "^5.4.1",
         "glob": "^11.0.1"
@@ -466,6 +467,133 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@github/copilot": {
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-0.0.414.tgz",
+      "integrity": "sha512-jseJ2S02CLWrFks5QK22zzq7as2ErY5m1wMCFBOE6sro1uACq1kvqqM1LwM4qy58YSZFrM1ZAn1s7UOVd9zhIA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "0.0.414",
+        "@github/copilot-darwin-x64": "0.0.414",
+        "@github/copilot-linux-arm64": "0.0.414",
+        "@github/copilot-linux-x64": "0.0.414",
+        "@github/copilot-win32-arm64": "0.0.414",
+        "@github/copilot-win32-x64": "0.0.414"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-0.0.414.tgz",
+      "integrity": "sha512-PW4v89v41i4Mg/NYl4+gEhwnDaVz+olNL+RbqtiQI3IV89gZdS+RZQbUEJfOwMaFcT2GfiUK1OuB+YDv5GrkBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-0.0.414.tgz",
+      "integrity": "sha512-NyPYm0NovQTwtuI42WJIi4cjYd2z0wBHEvWlUSczRsSuYEyImAClmZmBPegUU63e5JdZd1PdQkQ7FqrrfL2fZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-0.0.414.tgz",
+      "integrity": "sha512-VgdRsvA1FiZ1lcU/AscSvyJWEUWZzoXv2tSZ6WV3NE0uUTuO1Qoq4xuqbKZ/+vKJmn1b8afe7sxAAOtCoWPBHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-0.0.414.tgz",
+      "integrity": "sha512-3HyZsbZqYTF5jcT7/e+nDIYBCQXo8UCVWjBI3raOE4lzAw9b2ucL290IhtA23s1+EiquMxJ4m3FnjwFmwlQ12A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.1.26.tgz",
+      "integrity": "sha512-5YsApwYa/k2VqaNGvB+ngvWIRxyBR+AY17wCX3ceo+0UcwR7RbW0Ld8l8c5wFOh8Qa/UN4/kXb10HRUTYelGUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^0.0.414",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-0.0.414.tgz",
+      "integrity": "sha512-8gdaoF4MPpeV0h8UnCZ8TKI5l274EP0fvAaV9BGjsdyEydDcEb+DHqQiXgitWVKKiHAAaPi12aH8P5OsEDUneQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "0.0.414",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-0.0.414.tgz",
+      "integrity": "sha512-E1Oq1jXHaL1oWNsmmiCd4G30/CfgVdswg/T5oDFUxx3Ri+6uBekciIzdyCDelsP1kn2+fC1EYz2AerQ6F+huzg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2172,6 +2300,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2202,6 +2339,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dispatch-tasks",
   "version": "0.1.0",
-  "description": "AI agent orchestration CLI — parse markdown task files, dispatch each unit of work to OpenCode, and commit results with conventional commits",
+  "description": "AI agent orchestration CLI — parse markdown task files, dispatch each unit of work to code agents (OpenCode, GitHub Copilot, etc.), and commit results with conventional commits",
   "type": "module",
   "bin": {
     "dispatch": "./dist/cli.js"
@@ -20,6 +20,7 @@
   "keywords": [
     "cli",
     "opencode",
+    "copilot",
     "ai",
     "agent",
     "orchestration",
@@ -32,6 +33,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "@github/copilot-sdk": "^0.1.0",
     "@opencode-ai/sdk": "^1.2.10",
     "chalk": "^5.4.1",
     "glob": "^11.0.1"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,13 +8,16 @@
  * Options:
  *   --dry-run         List tasks without executing
  *   --concurrency N   Max parallel dispatches (default: 1)
- *   --server-url URL  Connect to a running OpenCode server
+ *   --provider NAME   Agent backend: opencode, copilot (default: opencode)
+ *   --server-url URL  Connect to a running provider server
  *   --help            Show usage information
  */
 
 import { resolve } from "node:path";
 import { orchestrate } from "./orchestrator.js";
 import { log } from "./logger.js";
+import type { ProviderName } from "./provider.js";
+import { PROVIDER_NAMES } from "./providers/index.js";
 
 const HELP = `
   dispatch — AI agent orchestration CLI
@@ -27,13 +30,15 @@ const HELP = `
     --dry-run              List tasks without dispatching
     --no-plan              Skip the planner agent, dispatch directly
     --concurrency <n>      Max parallel dispatches (default: 1)
-    --server-url <url>     URL of a running OpenCode server
+    --provider <name>      Agent backend: ${PROVIDER_NAMES.join(", ")} (default: opencode)
+    --server-url <url>     URL of a running provider server
     --cwd <dir>            Working directory (default: cwd)
     -h, --help             Show this help
     -v, --version          Show version
 
   Examples:
     dispatch "tasks/**/*.md"
+    dispatch "tasks/**/*.md" --provider copilot
     dispatch "tasks/**/*.md" --dry-run
     dispatch "tasks/**/*.md" --concurrency 3
     dispatch "tasks/**/*.md" --server-url http://localhost:4096
@@ -44,6 +49,7 @@ interface CliArgs {
   dryRun: boolean;
   noPlan: boolean;
   concurrency: number;
+  provider: ProviderName;
   serverUrl?: string;
   cwd: string;
   help: boolean;
@@ -56,6 +62,7 @@ function parseArgs(argv: string[]): CliArgs {
     dryRun: false,
     noPlan: false,
     concurrency: 1,
+    provider: "opencode",
     cwd: process.cwd(),
     help: false,
     version: false,
@@ -81,6 +88,14 @@ function parseArgs(argv: string[]): CliArgs {
         process.exit(1);
       }
       args.concurrency = val;
+    } else if (arg === "--provider") {
+      i++;
+      const val = argv[i];
+      if (!PROVIDER_NAMES.includes(val as ProviderName)) {
+        log.error(`Unknown provider "${val}". Available: ${PROVIDER_NAMES.join(", ")}`);
+        process.exit(1);
+      }
+      args.provider = val as ProviderName;
     } else if (arg === "--server-url") {
       i++;
       args.serverUrl = argv[i];
@@ -126,6 +141,7 @@ async function main() {
     concurrency: args.concurrency,
     dryRun: args.dryRun,
     noPlan: args.noPlan,
+    provider: args.provider,
     serverUrl: args.serverUrl,
   });
 

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -1,9 +1,9 @@
 /**
- * OpenCode SDK dispatcher — creates a fresh session per task to keep
- * contexts isolated and avoid context rot.
+ * Task dispatcher — creates a fresh session per task to keep contexts
+ * isolated and avoid context rot. Works with any registered provider.
  */
 
-import { createOpencode, createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk";
+import type { ProviderInstance } from "./provider.js";
 import type { Task } from "./parser.js";
 
 export interface DispatchResult {
@@ -12,70 +12,26 @@ export interface DispatchResult {
   error?: string;
 }
 
-export interface OpencodeInstance {
-  client: OpencodeClient;
-  cleanup?: () => Promise<void>;
-}
-
 /**
- * Boot an OpenCode instance — either connect to a running server
- * or start a new one.
- */
-export async function bootOpencode(opts?: {
-  url?: string;
-}): Promise<OpencodeInstance> {
-  if (opts?.url) {
-    const client = createOpencodeClient({ baseUrl: opts.url });
-    return { client };
-  }
-
-  const oc = await createOpencode();
-  return {
-    client: oc.client,
-    cleanup: async () => {
-      oc.server.close();
-    },
-  };
-}
-
-/**
- * Dispatch a single task to OpenCode in its own session.
- * Uses the synchronous `session.prompt()` which blocks until the
- * agent finishes — each task gets a fresh session for context isolation.
+ * Dispatch a single task to the provider in its own session.
+ * Each task gets a fresh session for context isolation.
  *
  * When a `plan` is provided (from the planner agent), it replaces the
  * generic prompt with the planner's context-rich execution instructions.
  */
 export async function dispatchTask(
-  instance: OpencodeInstance,
+  instance: ProviderInstance,
   task: Task,
   cwd: string,
   plan?: string
 ): Promise<DispatchResult> {
-  const { client } = instance;
-
   try {
-    // Create a fresh session for this task — isolated context
-    const { data: session } = await client.session.create();
-    if (!session) {
-      return { task, success: false, error: "Failed to create session" };
-    }
-
+    const sessionId = await instance.createSession();
     const prompt = plan ? buildPlannedPrompt(task, cwd, plan) : buildPrompt(task, cwd);
 
-    // session.prompt() is synchronous — blocks until the agent completes
-    const { data: response, error } = await client.session.prompt({
-      path: { id: session.id },
-      body: {
-        parts: [{ type: "text", text: prompt }],
-      },
-    });
+    const response = await instance.prompt(sessionId, prompt);
 
-    if (error) {
-      return { task, success: false, error: `Prompt failed: ${JSON.stringify(error)}` };
-    }
-
-    if (!response) {
+    if (response === null) {
       return { task, success: false, error: "No response from agent" };
     }
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -2,18 +2,21 @@
  * Orchestrator — the core loop that drives the dispatch pipeline:
  *   1. Glob for task files
  *   2. Parse unchecked tasks
- *   3. Dispatch each to OpenCode in an isolated session
- *   4. Mark complete in markdown
- *   5. Commit with conventional commits
+ *   3. Boot the selected provider (OpenCode, Copilot, etc.)
+ *   4. Dispatch each task in an isolated session
+ *   5. Mark complete in markdown
+ *   6. Commit with conventional commits
  */
 
 import { glob } from "glob";
 import { parseTaskFile, markTaskComplete, buildTaskContext, type Task, type TaskFile } from "./parser.js";
-import { bootOpencode, dispatchTask, type DispatchResult } from "./dispatcher.js";
+import { dispatchTask, type DispatchResult } from "./dispatcher.js";
 import { planTask } from "./planner.js";
 import { commitTask } from "./git.js";
 import { log } from "./logger.js";
 import { createTui, type TaskState } from "./tui.js";
+import type { ProviderName } from "./provider.js";
+import { bootProvider } from "./providers/index.js";
 
 export interface DispatchOptions {
   pattern: string;
@@ -23,6 +26,8 @@ export interface DispatchOptions {
   serverUrl?: string;
   /** Skip the planner agent and dispatch tasks directly */
   noPlan?: boolean;
+  /** Which agent backend to use (default: "opencode") */
+  provider?: ProviderName;
 }
 
 export interface DispatchSummary {
@@ -34,7 +39,7 @@ export interface DispatchSummary {
 }
 
 export async function orchestrate(opts: DispatchOptions): Promise<DispatchSummary> {
-  const { pattern, cwd, concurrency, dryRun, serverUrl, noPlan } = opts;
+  const { pattern, cwd, concurrency, dryRun, serverUrl, noPlan, provider = "opencode" } = opts;
 
   // Dry-run mode uses simple log output
   if (dryRun) {
@@ -43,6 +48,7 @@ export async function orchestrate(opts: DispatchOptions): Promise<DispatchSummar
 
   // ── Start TUI ───────────────────────────────────────────────
   const tui = createTui();
+  tui.state.provider = provider;
 
   try {
     // ── 1. Discover task files ──────────────────────────────────
@@ -89,9 +95,9 @@ export async function orchestrate(opts: DispatchOptions): Promise<DispatchSummar
       status: "pending" as const,
     }));
 
-    // ── 3. Boot OpenCode ────────────────────────────────────────
+    // ── 3. Boot provider ────────────────────────────────────────
     tui.state.phase = "booting";
-    const instance = await bootOpencode({ url: serverUrl });
+    const instance = await bootProvider(provider, { url: serverUrl, cwd });
     if (serverUrl) {
       tui.state.serverUrl = serverUrl;
     }
@@ -156,9 +162,7 @@ export async function orchestrate(opts: DispatchOptions): Promise<DispatchSummar
     }
 
     // ── 5. Cleanup ──────────────────────────────────────────────
-    if (instance.cleanup) {
-      await instance.cleanup();
-    }
+    await instance.cleanup();
 
     tui.state.phase = "done";
     tui.stop();

--- a/src/planner.ts
+++ b/src/planner.ts
@@ -2,15 +2,14 @@
  * Planner agent — explores the codebase and researches the implementation
  * for a task, then produces a focused system prompt for the executor agent.
  *
- * The planner runs in its own OpenCode session with read-only intent: it
- * reads files, searches symbols, and reasons about the task without making
- * any changes. Its output is a rich, context-aware prompt that the executor
- * can use to make precise edits.
+ * The planner runs in its own session with read-only intent: it reads files,
+ * searches symbols, and reasons about the task without making any changes.
+ * Its output is a rich, context-aware prompt that the executor can follow
+ * to make precise edits.
  */
 
-import type { OpencodeInstance } from "./dispatcher.js";
+import type { ProviderInstance } from "./provider.js";
 import type { Task } from "./parser.js";
-import type { Part, TextPart } from "@opencode-ai/sdk";
 
 export interface PlanResult {
   /** The system prompt for the executor agent */
@@ -30,40 +29,18 @@ export interface PlanResult {
  * notes, implementation details) as additional guidance.
  */
 export async function planTask(
-  instance: OpencodeInstance,
+  instance: ProviderInstance,
   task: Task,
   cwd: string,
   fileContext?: string
 ): Promise<PlanResult> {
-  const { client } = instance;
-
   try {
-    const { data: session } = await client.session.create();
-    if (!session) {
-      return { prompt: "", success: false, error: "Failed to create planning session" };
-    }
-
+    const sessionId = await instance.createSession();
     const prompt = buildPlannerPrompt(task, cwd, fileContext);
 
-    const { data: response, error } = await client.session.prompt({
-      path: { id: session.id },
-      body: {
-        parts: [{ type: "text", text: prompt }],
-      },
-    });
+    const plan = await instance.prompt(sessionId, prompt);
 
-    if (error) {
-      return { prompt: "", success: false, error: `Planner failed: ${JSON.stringify(error)}` };
-    }
-
-    if (!response) {
-      return { prompt: "", success: false, error: "No response from planner" };
-    }
-
-    // Extract text content from the response parts
-    const plan = extractText(response.parts);
-
-    if (!plan.trim()) {
+    if (!plan?.trim()) {
       return { prompt: "", success: false, error: "Planner returned empty plan" };
     }
 
@@ -140,14 +117,4 @@ function buildPlannerPrompt(task: Task, cwd: string, fileContext?: string): stri
   );
 
   return sections.join("\n");
-}
-
-/**
- * Extract all text content from response parts.
- */
-function extractText(parts: Part[]): string {
-  const textParts = parts.filter(
-    (p): p is TextPart => p.type === "text" && "text" in p
-  );
-  return textParts.map((p) => p.text).join("\n");
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,0 +1,52 @@
+/**
+ * Provider interface — abstracts the underlying AI agent runtime so that
+ * new code agents (OpenCode, Copilot, Claude Code, etc.) can be added by
+ * implementing a single interface.
+ *
+ * Each provider manages its own server lifecycle, session isolation, and
+ * prompt/response serialization. The orchestrator interacts exclusively
+ * through this contract.
+ */
+
+export type ProviderName = "opencode" | "copilot";
+
+/**
+ * Options passed when booting a provider.
+ */
+export interface ProviderBootOptions {
+  /** Connect to an already-running server at this URL instead of spawning one */
+  url?: string;
+  /** Working directory for the agent */
+  cwd?: string;
+}
+
+/**
+ * A booted provider instance that can create sessions and send prompts.
+ *
+ * To add support for a new agent backend:
+ *   1. Create `src/providers/<name>.ts`
+ *   2. Export an async `boot` function that returns a `ProviderInstance`
+ *   3. Register it in `src/providers/index.ts`
+ */
+export interface ProviderInstance {
+  /** Human-readable provider name (e.g. "opencode", "copilot") */
+  readonly name: string;
+
+  /**
+   * Create a new isolated session for a single task.
+   * Returns an opaque session identifier.
+   */
+  createSession(): Promise<string>;
+
+  /**
+   * Send a prompt to an existing session and wait for the agent to finish.
+   * Returns the agent's text response, or null if no response was produced.
+   */
+  prompt(sessionId: string, text: string): Promise<string | null>;
+
+  /**
+   * Tear down the provider — stop servers, release resources.
+   * Safe to call multiple times.
+   */
+  cleanup(): Promise<void>;
+}

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -1,0 +1,62 @@
+/**
+ * GitHub Copilot provider — wraps the @github/copilot-sdk to conform
+ * to the generic ProviderInstance interface.
+ *
+ * Requires the `copilot` CLI to be installed and available on PATH
+ * (or specify the path via COPILOT_CLI_PATH).
+ *
+ * Authentication options:
+ *   - Logged-in Copilot CLI user (default)
+ *   - COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN env vars
+ */
+
+import { CopilotClient, type CopilotSession } from "@github/copilot-sdk";
+import type { ProviderInstance, ProviderBootOptions } from "../provider.js";
+
+/**
+ * Boot a Copilot provider instance — starts or connects to a Copilot CLI server.
+ */
+export async function boot(opts?: ProviderBootOptions): Promise<ProviderInstance> {
+  const client = new CopilotClient({
+    ...(opts?.url ? { cliUrl: opts.url } : {}),
+  });
+
+  await client.start();
+
+  // Track live sessions for prompt routing and cleanup
+  const sessions = new Map<string, CopilotSession>();
+
+  return {
+    name: "copilot",
+
+    async createSession(): Promise<string> {
+      const session = await client.createSession();
+      sessions.set(session.sessionId, session);
+      return session.sessionId;
+    },
+
+    async prompt(sessionId: string, text: string): Promise<string | null> {
+      const session = sessions.get(sessionId);
+      if (!session) {
+        throw new Error(`Copilot session ${sessionId} not found`);
+      }
+
+      const event = await session.sendAndWait({ prompt: text });
+
+      // Extract response text from the completion event
+      if (!event) return null;
+      return event.data?.content ?? null;
+    },
+
+    async cleanup(): Promise<void> {
+      // Destroy all active sessions before stopping the server
+      const destroyOps = [...sessions.values()].map((s) =>
+        s.destroy().catch(() => {})
+      );
+      await Promise.all(destroyOps);
+      sessions.clear();
+
+      await client.stop().catch(() => {});
+    },
+  };
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Provider registry — maps provider names to their boot functions.
+ *
+ * To add a new agent backend:
+ *   1. Create `src/providers/<name>.ts` exporting an async `boot()` function
+ *   2. Import and register it in the `PROVIDERS` map below
+ *   3. Add the name to the `ProviderName` union in `src/provider.ts`
+ */
+
+import type { ProviderName, ProviderInstance, ProviderBootOptions } from "../provider.js";
+import { boot as bootOpencode } from "./opencode.js";
+import { boot as bootCopilot } from "./copilot.js";
+
+type BootFn = (opts?: ProviderBootOptions) => Promise<ProviderInstance>;
+
+const PROVIDERS: Record<ProviderName, BootFn> = {
+  opencode: bootOpencode,
+  copilot: bootCopilot,
+};
+
+/**
+ * All registered provider names — useful for CLI help text and validation.
+ */
+export const PROVIDER_NAMES = Object.keys(PROVIDERS) as ProviderName[];
+
+/**
+ * Boot a provider by name.
+ *
+ * @throws if the provider name is not registered.
+ */
+export async function bootProvider(
+  name: ProviderName,
+  opts?: ProviderBootOptions
+): Promise<ProviderInstance> {
+  const bootFn = PROVIDERS[name];
+  if (!bootFn) {
+    throw new Error(
+      `Unknown provider "${name}". Available: ${PROVIDER_NAMES.join(", ")}`
+    );
+  }
+  return bootFn(opts);
+}

--- a/src/providers/opencode.ts
+++ b/src/providers/opencode.ts
@@ -1,0 +1,67 @@
+/**
+ * OpenCode provider — wraps the @opencode-ai/sdk to conform to the
+ * generic ProviderInstance interface.
+ */
+
+import {
+  createOpencode,
+  createOpencodeClient,
+  type OpencodeClient,
+  type Part,
+  type TextPart,
+} from "@opencode-ai/sdk";
+import type { ProviderInstance, ProviderBootOptions } from "../provider.js";
+
+/**
+ * Boot an OpenCode instance — either connect to a running server
+ * or start a new one.
+ */
+export async function boot(opts?: ProviderBootOptions): Promise<ProviderInstance> {
+  let client: OpencodeClient;
+  let stopServer: (() => void) | undefined;
+
+  if (opts?.url) {
+    client = createOpencodeClient({ baseUrl: opts.url });
+  } else {
+    const oc = await createOpencode();
+    client = oc.client;
+    stopServer = () => oc.server.close();
+  }
+
+  return {
+    name: "opencode",
+
+    async createSession(): Promise<string> {
+      const { data: session } = await client.session.create();
+      if (!session) {
+        throw new Error("Failed to create OpenCode session");
+      }
+      return session.id;
+    },
+
+    async prompt(sessionId: string, text: string): Promise<string | null> {
+      const { data: response, error } = await client.session.prompt({
+        path: { id: sessionId },
+        body: {
+          parts: [{ type: "text", text }],
+        },
+      });
+
+      if (error) {
+        throw new Error(`OpenCode prompt failed: ${JSON.stringify(error)}`);
+      }
+
+      if (!response) return null;
+
+      // Extract text from response parts
+      const textParts = response.parts.filter(
+        (p: Part): p is TextPart => p.type === "text" && "text" in p
+      );
+      return textParts.map((p: TextPart) => p.text).join("\n") || null;
+    },
+
+    async cleanup(): Promise<void> {
+      stopServer?.();
+    },
+  };
+}

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -21,6 +21,8 @@ export interface TuiState {
   startTime: number;
   filesFound: number;
   serverUrl?: string;
+  /** Active provider name — shown in the booting phase */
+  provider?: string;
 }
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -84,14 +86,16 @@ function statusLabel(status: TaskStatus): string {
   }
 }
 
-function phaseLabel(phase: TuiState["phase"]): string {
+function phaseLabel(phase: TuiState["phase"], provider?: string): string {
   switch (phase) {
     case "discovering":
       return `${spinner()} Discovering task files...`;
     case "parsing":
       return `${spinner()} Parsing tasks...`;
-    case "booting":
-      return `${spinner()} Connecting to OpenCode...`;
+    case "booting": {
+      const name = provider ?? "provider";
+      return `${spinner()} Connecting to ${name}...`;
+    }
     case "dispatching":
       return `${spinner()} Dispatching tasks...`;
     case "done":
@@ -114,7 +118,7 @@ function render(state: TuiState): string {
   lines.push(chalk.dim("  ─".repeat(24)));
 
   // ── Phase + Timer ───────────────────────────────────────────
-  lines.push(`  ${phaseLabel(state.phase)}` + chalk.dim(`  ${totalElapsed}`));
+  lines.push(`  ${phaseLabel(state.phase, state.provider)}` + chalk.dim(`  ${totalElapsed}`));
 
   if (state.phase === "dispatching" || state.phase === "done") {
     // ── Progress bar ────────────────────────────────────────


### PR DESCRIPTION
Introduce a ProviderInstance interface that abstracts the underlying
AI agent runtime, making it straightforward to add new code agent
backends. Refactor the existing OpenCode integration into this pattern
and add GitHub Copilot as a second provider using @github/copilot-sdk.

New files:
- src/provider.ts — ProviderInstance interface contract
- src/providers/opencode.ts — OpenCode SDK provider
- src/providers/copilot.ts — GitHub Copilot SDK provider
- src/providers/index.ts — provider registry and boot factory

Updated files:
- dispatcher.ts, planner.ts — decoupled from OpenCode, use ProviderInstance
- orchestrator.ts — boots provider by name via registry
- cli.ts — new --provider flag (opencode | copilot)
- tui.ts — shows active provider name during boot phase
- package.json — added @github/copilot-sdk dependency

https://claude.ai/code/session_01ASmhhgZD5vnQQttgt9GGTV