### PR TITLE
Update CLI documentation 

### DIFF
--- a/docs/cli-orchestration/cli.md
+++ b/docs/cli-orchestration/cli.md
@@ -81,7 +81,7 @@ The package has four runtime dependencies:
 ## Why a custom parser instead of commander/yargs?
 
 The project uses a hand-rolled `parseArgs()` function
-(`src/cli.ts:83-186`) rather than an established CLI framework like
+(`src/cli.ts:97-232`) rather than an established CLI framework like
 [commander](https://github.com/tj/commander.js),
 [yargs](https://yargs.js.org/), or
 [citty](https://github.com/unjs/citty).
@@ -92,8 +92,8 @@ The likely reasons are:
   The only runtime dependencies are `chalk`, `glob`, and the two provider SDKs.
   Adding a CLI framework would add another dependency (and its transitive
   dependencies) for a relatively simple argument surface.
-- **Small option set**: Dispatch has 14 options across two modes. A hand-rolled
-  parser for this surface area is straightforward and fits in ~100 lines.
+- **Small option set**: Dispatch has 17 options across two modes. A hand-rolled
+  parser for this surface area is straightforward and fits in ~135 lines.
 - **Full control**: The parser can exit immediately with targeted error messages
   (e.g., provider validation against [`PROVIDER_NAMES`](../provider-system/provider-overview.md#the-provider-registry)) without mapping through
   a framework's validation API.
@@ -133,6 +133,8 @@ checks for `--server-url` and `--cwd`.
 | `--concurrency <n>` | integer | `min(cpus, freeMB/500)` | Maximum parallel dispatches per batch (see [concurrency model](orchestrator.md#concurrency-model) and [default computation](configuration.md#default-concurrency-computation)) |
 | `--provider <name>` | string | `"opencode"` | AI agent backend (`opencode` or `copilot`); see [Provider Abstraction](../provider-system/provider-overview.md) |
 | `--server-url <url>` | string | *none* | Connect to a running provider server instead of starting one |
+| `--plan-timeout <min>` | float | `10` | Planning timeout in minutes. Must be a positive number. Parsed via `parseFloat`. Configurable via `dispatch config set planTimeout`. |
+| `--plan-retries <n>` | integer | `1` | Number of retry attempts after planning timeout. Must be a non-negative integer. Parsed via `parseInt`. Configurable via `dispatch config set planRetries`. |
 | `--cwd <dir>` | string | `process.cwd()` | Working directory for file discovery and agent execution |
 | `--verbose` | boolean | `false` | Show detailed debug output for troubleshooting |
 | `-h`, `--help` | boolean | `false` | Show usage information |
@@ -140,25 +142,28 @@ checks for `--server-url` and `--cwd`.
 
 ### Spec mode options
 
-Spec mode is activated by passing `--spec`. When active, the issue IDs are
-not required and the dispatch-specific flags (`--dry-run`, `--no-plan`,
-`--concurrency`) are ignored.
+Spec mode is activated by passing `--spec` or `--respec`. When active, the
+issue IDs are not required and the dispatch-specific flags (`--dry-run`,
+`--no-plan`, `--concurrency`) are ignored.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--spec <values...>` | string (one or more) | *none* | Comma-separated issue numbers, multiple space-separated args, or a glob pattern for local `.md` files. Activates spec mode. See [issue IDs vs glob patterns](configuration.md#the---spec-flag-issue-ids-vs-glob-patterns). |
+| `--spec <values...>` | string (one or more) | *none* | Comma-separated issue numbers, multiple space-separated args, glob pattern for local `.md` files, or inline text description. Activates spec mode. See [issue IDs vs glob patterns](configuration.md#the---spec-flag-issue-ids-vs-glob-patterns). |
+| `--respec [values...]` | string (zero or more) | *none* | Regenerate existing specs. Accepts the same value types as `--spec` (issue numbers, glob, multiple args), or can be passed with no arguments to regenerate all existing specs. Uses variadic collection — consumes all subsequent non-flag arguments. An empty invocation (`--respec` with no args or immediately followed by another flag) produces an empty array. |
 | `--source <name>` | string | *auto-detected* | Datasource: `github`, `azdevops`, or `md`. Auto-detected from `git remote get-url origin` if omitted. See [datasource detection](configuration.md#auto-detection-from-git-remote) and [Datasource Overview](../datasource-system/overview.md). |
 | `--org <url>` | string | *none* | Azure DevOps organization URL (e.g., `https://dev.azure.com/myorg`). Required when `--source azdevops`. |
 | `--project <name>` | string | *none* | Azure DevOps project name. Required when `--source azdevops`. |
 | `--output-dir <dir>` | string | `.dispatch/specs` | Output directory for generated spec files. Resolved to an absolute path. Created automatically if it does not exist. |
 | `--provider <name>` | string | `"opencode"` | AI agent backend (shared with dispatch mode) |
 | `--server-url <url>` | string | *none* | Connect to a running provider server (shared with dispatch mode) |
+| `--plan-timeout <min>` | float | `10` | Planning timeout in minutes (shared with dispatch mode) |
+| `--plan-retries <n>` | integer | `1` | Retry attempts after planning timeout (shared with dispatch mode) |
 
 #### Spec mode validation
 
 The `--source` flag is validated against `DATASOURCE_NAMES` (currently
 `["github", "azdevops", "md"]`). An unknown value exits with code `1` and a
-descriptive error message (`src/cli.ts:129-134`).
+descriptive error message (`src/cli.ts:157-161`).
 
 When `--source` is omitted, auto-detection runs `git remote get-url origin` and
 matches the output against regex patterns for `github.com` (SSH and HTTPS) and
@@ -166,6 +171,37 @@ matches the output against regex patterns for `github.com` (SSH and HTTPS) and
 the pipeline aborts with an error suggesting `--source` be specified explicitly.
 See the [Spec Generation overview](../spec-generation/overview.md) for the
 full detection logic.
+
+#### `--spec` and `--respec` variadic parsing
+
+Both `--spec` and `--respec` use variadic collection loops
+(`src/cli.ts:134-143` and `src/cli.ts:144-153`) that consume all subsequent
+non-flag arguments (arguments not starting with `--`). The collection stops
+when the next `--`-prefixed flag is encountered or the argument list is
+exhausted.
+
+- **Single value**: stored as a string (e.g., `--spec 42` produces `"42"`)
+- **Multiple values**: stored as an array (e.g., `--spec 42 43` produces
+  `["42", "43"]`)
+- **Empty** (no args before next flag or end of input): produces an empty
+  array for `--respec` (e.g., `--respec --verbose` produces `[]`); `--spec`
+  with no arguments also produces an empty array.
+
+The `--spec` and `--respec` flags are not mutually exclusive at the parser
+level. Both can be set simultaneously in `ParsedArgs`. Mutual exclusion is
+enforced downstream by the orchestrator (`src/agents/orchestrator.ts`), which
+checks for both and produces an error.
+
+Examples:
+
+```bash
+dispatch --respec                        # respec = []     (regenerate all)
+dispatch --respec 42                     # respec = "42"   (single issue)
+dispatch --respec 42 43 44              # respec = ["42", "43", "44"]
+dispatch --respec "specs/*.md"          # respec = "specs/*.md"
+dispatch --respec --verbose             # respec = []     (empty, --verbose consumed separately)
+dispatch --spec 1,2 --respec 3,4       # spec = "1,2", respec = "3,4" (both set)
+```
 
 ## The `--server-url` option
 
@@ -190,7 +226,7 @@ process and manages its lifecycle internally.
 
 ## The `--no-branch` flag
 
-The `--no-branch` flag (`src/cli.ts:122-124`) disables the per-issue branch
+The `--no-branch` flag (`src/cli.ts:128-130`) disables the per-issue branch
 lifecycle that the dispatch pipeline normally performs. It is a boolean flag
 parsed into `explicitFlags` as `"noBranch"` and passed through to the
 orchestrator's `OrchestrateRunOptions.noBranch` field.
@@ -270,7 +306,7 @@ sequenceDiagram
 ## Exit code contract
 
 The CLI uses a binary exit code scheme with additional signal codes.
-The primary exit logic is at `src/cli.ts:231-232`:
+The primary exit logic is at `src/cli.ts:277-278`:
 
 | Exit code | Meaning |
 |-----------|---------|
@@ -291,13 +327,13 @@ information. A future enhancement could add `--json` output or distinct exit
 codes (e.g., `2` for partial failure).
 
 Unhandled exceptions from `main()` are caught by the top-level `.catch()`
-handler (`src/cli.ts:235-238`), which logs the error message, calls
+handler (`src/cli.ts:281-284`), which logs the error message, calls
 `runCleanup()` to release provider resources, and exits with code `1`.
 
 ## Version string and tsup define
 
 The version string is currently hardcoded as `"dispatch v0.1.0"` at
-`src/cli.ts:221`. The adjacent comment says `// Read version from package.json
+`src/cli.ts:267`. The adjacent comment says `// Read version from package.json
 at build time via tsup define`, indicating the intent to inject the version at
 build time.
 
@@ -339,7 +375,7 @@ export default defineConfig({
 });
 ```
 
-Then `src/cli.ts:128` would become:
+Then `src/cli.ts` would become:
 
 ```typescript
 console.log(`dispatch v${__VERSION__}`);
@@ -362,7 +398,7 @@ flowchart TD
     G -->|No| I["bootOrchestrator({ cwd })"]
     I --> J["orchestrator.runFromCli(args)"]
     J --> K["resolveCliConfig(args)<br/>merge config + validate"]
-    K --> L{"--spec?"}
+    K --> L{"--spec or --respec?"}
     L -->|Yes| M["Spec pipeline"]
     L -->|No| N["Dispatch pipeline"]
     M --> O["Summary"]
@@ -376,8 +412,8 @@ flowchart TD
 
 The key architectural change from earlier versions is that the CLI no longer
 directly calls `generateSpecs()` or `orchestrate()`. Instead, it delegates to
-`bootOrchestrator()` (`src/cli.ts:226`) which returns an orchestrator instance,
-then calls `orchestrator.runFromCli(args)` (`src/cli.ts:228`). The orchestrator
+`bootOrchestrator()` (`src/cli.ts:272`) which returns an orchestrator instance,
+then calls `orchestrator.runFromCli(args)` (`src/cli.ts:274`). The orchestrator
 internally calls `resolveCliConfig()` to merge config-file defaults with CLI
 flags before routing to the appropriate pipeline. See
 [Configuration](configuration.md) for full details on the resolution process.
@@ -404,4 +440,5 @@ flags before routing to the appropriate pipeline. See
 - [Datasource System](../datasource-system/overview.md) -- datasource
   abstraction and `--source` flag semantics
 - [Testing Overview](../testing/overview.md) -- test suite structure and
-  coverage (CLI is not currently unit-tested)
+  coverage (config tests cover `--respec` variadic parsing and
+  `--spec`/`--respec` mutual exclusion)

--- a/docs/cli-orchestration/configuration.md
+++ b/docs/cli-orchestration/configuration.md
@@ -11,7 +11,7 @@ flags, and config subcommand handling embedded in the CLI entry point
 
 The configuration system allows users to set persistent defaults for frequently
 used CLI options, avoiding the need to pass `--provider copilot --source github`
-on every invocation. It supports six configurable keys and provides a
+on every invocation. It supports eight configurable keys and provides a
 `dispatch config` subcommand for managing stored values.
 
 ## Why it exists
@@ -59,7 +59,9 @@ The config file is a plain JSON object with optional fields:
   "source": "github",
   "org": "https://dev.azure.com/myorg",
   "project": "MyProject",
-  "serverUrl": "http://localhost:4096"
+  "serverUrl": "http://localhost:4096",
+  "planTimeout": 10,
+  "planRetries": 1
 }
 ```
 
@@ -90,7 +92,7 @@ is created with the default `mkdir` permissions (typically `0755`).
 
 ### Is the config file format versioned?
 
-No. The `DispatchConfig` interface (`src/config.ts:20-27`) defines the schema,
+No. The `DispatchConfig` interface (`src/config.ts:20-29`) defines the schema,
 but there is no version field, no migration logic, and no schema validation
 beyond per-key type checks. When new keys are added to `DispatchConfig` in
 future releases:
@@ -115,10 +117,12 @@ handles the common cases without explicit versioning.
 | `org` | string | Any non-empty string | Azure DevOps organization URL |
 | `project` | string | Any non-empty string | Azure DevOps project name |
 | `serverUrl` | string | Any non-empty string | URL of a running provider server |
+| `planTimeout` | number | Positive number (e.g., 0.5, 1, 10) | Planning timeout in minutes. Parsed via `parseFloat`. |
+| `planRetries` | number | Non-negative integer (0, 1, 2, ...) | Number of retry attempts after planning timeout. Parsed via `parseInt`. |
 
 ### Validation rules
 
-`validateConfigValue()` (`src/config.ts:91-124`) enforces type-specific rules:
+`validateConfigValue()` (`src/config.ts:95-143`) enforces type-specific rules:
 
 - **`provider`** must be in `PROVIDER_NAMES` (currently `"opencode"` or
   `"copilot"`). Invalid values produce:
@@ -129,6 +133,14 @@ handles the common cases without explicit versioning.
 - **`concurrency`** must parse to a positive integer. Values like `"0"`,
   `"-1"`, `"1.5"`, and `"abc"` are rejected.
 - **`org`**, **`project`**, **`serverUrl`** must be non-empty strings.
+- **`planTimeout`** must parse to a positive finite number via
+  `Number(value)`. Values like `"0"`, `"-5"`, `"abc"`, and `""` are rejected.
+  The error message is:
+  `Invalid planTimeout "<value>". Must be a positive number (minutes)`
+- **`planRetries`** must parse to a non-negative integer via
+  `Number(value)`. Values like `"-1"`, `"1.5"`, and `"abc"` are rejected.
+  The error message is:
+  `Invalid planRetries "<value>". Must be a non-negative integer`
 
 ### Config key to CLI field mapping
 
@@ -142,6 +154,8 @@ The config system uses different key names than the CLI in one case:
 | `org` | `--org` | `org` |
 | `project` | `--project` | `project` |
 | `serverUrl` | `--server-url` | `serverUrl` |
+| `planTimeout` | `--plan-timeout` | `planTimeout` |
+| `planRetries` | `--plan-retries` | `planRetries` |
 
 The `source` to `issueSource` mapping (`src/orchestrator/cli-config.ts:24`)
 is the only field where the config key differs from the CLI field name. This
@@ -151,7 +165,7 @@ of "source" in the codebase.
 
 ## The `dispatch config` subcommand
 
-The config subcommand (`src/config.ts:143-230`) supports five operations:
+The config subcommand (`src/config.ts:166-253`) supports five operations:
 
 ### `dispatch config set <key> <value>`
 
@@ -166,6 +180,8 @@ dispatch config set concurrency 3
 dispatch config set serverUrl http://localhost:4096
 dispatch config set org https://dev.azure.com/myorg
 dispatch config set project MyProject
+dispatch config set planTimeout 10
+dispatch config set planRetries 2
 ```
 
 ### `dispatch config get <key>`
@@ -242,7 +258,7 @@ flowchart TD
 
 ### How the `explicitFlags` set prevents config overrides
 
-The `parseArgs()` function in `src/cli.ts:83-186` builds a `Set<string>` of
+The `parseArgs()` function in `src/cli.ts:97-232` builds a `Set<string>` of
 CLI flag names that were explicitly provided by the user. Every time a flag
 is parsed, its corresponding field name is added to the set:
 
@@ -252,7 +268,7 @@ args.provider = val as ProviderName;
 explicitFlags.add("provider");  // marks "provider" as explicit
 ```
 
-During the merge step in `resolveCliConfig()` (`src/orchestrator/cli-config.ts:50-55`),
+During the merge step in `resolveCliConfig()` (`src/orchestrator/cli-config.ts:52-57`),
 each config key is checked against `explicitFlags`:
 
 ```
@@ -283,7 +299,7 @@ even if the config file says `"provider": "copilot"`.
 
 ### Why the config subcommand runs before `parseArgs`
 
-The `config` subcommand is intercepted at `src/cli.ts:192` before `parseArgs()`
+The `config` subcommand is intercepted at `src/cli.ts:238` before `parseArgs()`
 is called:
 
 ```
@@ -308,7 +324,7 @@ If this check ran after `parseArgs`, the following would break:
 ## Mandatory configuration validation
 
 After merging config-file defaults, `resolveCliConfig()` validates that two
-mandatory fields are configured (`src/orchestrator/cli-config.ts:57-80`):
+mandatory fields are configured (`src/orchestrator/cli-config.ts:59-82`):
 
 1. **`provider`** -- must be set via CLI flag (`--provider`) or config file
    (`dispatch config set provider <name>`).
@@ -329,10 +345,18 @@ remediation guidance:
 The process exits with code `1`.
 
 Note that `provider` has a hardcoded default of `"opencode"` in `parseArgs()`
-(`src/cli.ts:88`), so in practice the provider validation only fails if the
+(`src/cli.ts:103`), so in practice the provider validation only fails if the
 user has not set a provider in the config file AND the hardcoded default is
-somehow cleared. The `source` field has no hardcoded default, making it the
-field most likely to trigger the validation error on first use.
+somehow cleared. The validation checks `explicitFlags.has("provider") ||
+config.provider !== undefined` (`src/orchestrator/cli-config.ts:60-61`), which
+means it checks whether the flag was explicitly provided OR the config file has
+a value -- it does NOT check the merged value. Because `parseArgs` always sets
+`provider: "opencode"` as a default, the merged args always have a provider
+value, but the validation ignores that default. In practice this means provider
+validation only fails when neither the CLI flag nor the config file provides a
+value, even though the merged args contain `"opencode"`. The `source` field
+has no hardcoded default, making it the field most likely to trigger the
+validation error on first use.
 
 ## The `serverUrl` config option
 
@@ -465,10 +489,10 @@ The CLI produces the following exit codes:
 |-----------|---------|-----------------|
 | `0` | Success | `--help`, `--version`, `config` subcommand, or all tasks completed |
 | `1` | Failure | Any tasks failed, validation error, or unhandled exception |
-| `130` | SIGINT | User pressed Ctrl+C (`src/cli.ts:206`) |
-| `143` | SIGTERM | Process received SIGTERM (`src/cli.ts:212`) |
+| `130` | SIGINT | User pressed Ctrl+C (`src/cli.ts:252`) |
+| `143` | SIGTERM | Process received SIGTERM (`src/cli.ts:258`) |
 
-Exit code determination (`src/cli.ts:231-232`):
+Exit code determination (`src/cli.ts:277-278`):
 
 ```
 const failed = "failed" in summary ? summary.failed : 0;
@@ -481,7 +505,7 @@ of 10 tasks succeed but 1 fails, the exit code is `1`.
 ## Graceful shutdown and cleanup
 
 The CLI installs signal handlers for `SIGINT` and `SIGTERM` at
-`src/cli.ts:203-213`. Both handlers follow the same pattern:
+`src/cli.ts:249-258`. Both handlers follow the same pattern:
 
 1. Log a debug message (visible with `--verbose`).
 2. Call `runCleanup()` from the [cleanup registry](../shared-types/cleanup.md).
@@ -524,7 +548,7 @@ to force termination.
 ## Orchestrator boot process
 
 The CLI delegates to the orchestrator via a two-step process
-(`src/cli.ts:226-228`):
+(`src/cli.ts:272-274`):
 
 1. **`bootOrchestrator({ cwd })`**: Creates an `OrchestratorAgent` instance
    bound to the working directory. This is a lightweight operation that does
@@ -571,7 +595,8 @@ If the config file is deleted between `loadConfig()` and a subsequent
 ### Unknown config key error
 
 If `dispatch config set <key> <value>` reports an unknown key, the key must be
-one of: `provider`, `concurrency`, `source`, `org`, `project`, `serverUrl`.
+one of: `provider`, `concurrency`, `source`, `org`, `project`, `serverUrl`,
+`planTimeout`, `planRetries`.
 Keys like `dryRun`, `noPlan`, `noBranch`, and `verbose` are CLI-only flags and
 cannot be persisted. See [the --no-branch flag](cli.md#the---no-branch-flag)
 for details on that flag's behavior.

--- a/docs/cli-orchestration/integrations.md
+++ b/docs/cli-orchestration/integrations.md
@@ -304,10 +304,10 @@ and delete the persistent config file at `~/.dispatch/config.json`.
 
 | Function | Usage | Location |
 |----------|-------|----------|
-| `readFile` | Load config file contents as UTF-8 string | `src/config.ts:59` |
-| `writeFile` | Write pretty-printed JSON config to disk | `src/config.ts:77` |
-| `mkdir` | Create `~/.dispatch/` directory if it doesn't exist | `src/config.ts:76` |
-| `rm` | Delete config file during `config reset` | `src/config.ts:205` |
+| `readFile` | Load config file contents as UTF-8 string | `src/config.ts:63` |
+| `writeFile` | Write pretty-printed JSON config to disk | `src/config.ts:81` |
+| `mkdir` | Create `~/.dispatch/` directory if it doesn't exist | `src/config.ts:80` |
+| `rm` | Delete config file during `config reset` | `src/config.ts:228` |
 
 ### Config file location and permissions
 
@@ -357,7 +357,7 @@ locking (e.g., `flock`) would be needed.
 
 ## Node.js process (stdout, argv, exit)
 
-**Used in**: `src/cli.ts:119`, `src/cli.ts:148`, `src/tui.ts:130`,
+**Used in**: `src/cli.ts:234`, `src/cli.ts:240`, `src/tui.ts:130`,
 `src/tui.ts:201-204`
 **Official docs**: [nodejs.org/api/process.html](https://nodejs.org/api/process.html)
 
@@ -381,14 +381,15 @@ The CLI calls `process.exit()` at several points:
 
 | Location | Exit code | Reason |
 |----------|-----------|--------|
-| `src/cli.ts:123` | `0` | `--help` displayed |
-| `src/cli.ts:129` | `0` | `--version` displayed |
-| `src/cli.ts:135` | `1` | Missing glob pattern |
-| `src/cli.ts:148` | `0` or `1` | Normal completion (`1` if any task failed) |
-| `src/cli.ts:153` | `1` | Unhandled exception in `main()` |
-| `src/cli.ts:87` | `1` | Invalid `--concurrency` value |
-| `src/cli.ts:96` | `1` | Unknown `--provider` value |
-| `src/cli.ts:109` | `1` | Unknown CLI option |
+| `src/cli.ts:264` | `0` | `--help` displayed |
+| `src/cli.ts:268` | `0` | `--version` displayed |
+| `src/cli.ts:278` | `0` or `1` | Normal completion (`1` if any task failed) |
+| `src/cli.ts:284` | `1` | Unhandled exception in `main()` |
+| `src/cli.ts:183` | `1` | Invalid `--concurrency` value |
+| `src/cli.ts:192` | `1` | Unknown `--provider` value |
+| `src/cli.ts:205` | `1` | Invalid `--plan-timeout` value |
+| `src/cli.ts:213` | `1` | Invalid `--plan-retries` value |
+| `src/cli.ts:225` | `1` | Unknown CLI option |
 
 ### Raw ANSI escape codes in non-TTY environments
 
@@ -407,7 +408,7 @@ for the full impact assessment.
 
 ### Signal handling
 
-Dispatch installs `SIGINT` and `SIGTERM` handlers at `src/cli.ts:242-252`
+Dispatch installs `SIGINT` and `SIGTERM` handlers at `src/cli.ts:249-258`
 that call `runCleanup()` from the [cleanup registry](../shared-types/cleanup.md)
 before exiting. This ensures provider server processes are stopped on Ctrl+C
 or container shutdown.
@@ -418,7 +419,7 @@ or container shutdown.
 | SIGTERM | 143 | `kill <pid>`, container stop, process manager |
 
 Additionally, the `.catch()` handler on the `main()` promise
-(`src/cli.ts:304-307`) calls `runCleanup()` before `process.exit(1)` to
+(`src/cli.ts:281-284`) calls `runCleanup()` before `process.exit(1)` to
 handle unhandled exceptions.
 
 For full details on exit codes, double-signal behavior, hung shutdown

--- a/docs/cli-orchestration/orchestrator.md
+++ b/docs/cli-orchestration/orchestrator.md
@@ -13,7 +13,7 @@ The orchestrator exposes two entry points from the CLI:
 1. **`runFromCli(args)`**: Called by the CLI after `bootOrchestrator()`. This
    method first calls [`resolveCliConfig()`](configuration.md#three-tier-configuration-precedence)
    to merge config-file defaults with CLI flags, then routes to either the
-   spec pipeline (if `--spec` is present; see [Spec Generation](../spec-generation/overview.md)) or the dispatch pipeline.
+   spec pipeline (if `--spec` or `--respec` is present; see [Spec Generation](../spec-generation/overview.md)) or the dispatch pipeline.
 
 2. **`orchestrate()`**: The core dispatch function that accepts an
    `OrchestrateRunOptions` object and executes the dispatch pipeline
@@ -443,6 +443,8 @@ time via `bootOrchestrator({ cwd })` rather than passed per-invocation:
 | `source` | `DatasourceName?` | Datasource backend (`"github"`, `"azdevops"`, or `"md"`) |
 | `org` | `string?` | Azure DevOps organization URL |
 | `project` | `string?` | Azure DevOps project name |
+| `planTimeout` | `number?` | Planning timeout in minutes. Passed through from CLI `--plan-timeout` or config `planTimeout`. |
+| `planRetries` | `number?` | Number of retry attempts after planning timeout. Passed through from CLI `--plan-retries` or config `planRetries`. |
 
 ### DispatchSummary
 

--- a/docs/datasource-system/overview.md
+++ b/docs/datasource-system/overview.md
@@ -501,7 +501,5 @@ that all consumers handle the new backend at compile time.
   `--project`, and `--output-dir` flags
 - [CLI Orchestrator](../cli-orchestration/orchestrator.md) -- How the
   orchestrator invokes datasource operations and helpers
-- [Testing](./testing.md) -- Test suite covering the markdown datasource
-  and datasource registry
 - [Git Operations](../planning-and-dispatch/git.md) -- Post-completion git
   commits that run after datasource lifecycle operations

--- a/docs/testing/config-tests.md
+++ b/docs/testing/config-tests.md
@@ -17,7 +17,7 @@ The configuration module manages persistent user settings stored at
 
 ## Describe blocks
 
-The test file contains **8 describe blocks** with **27 tests** total.
+The test file contains **8 describe blocks** with **48 tests** total.
 
 ### loadConfig (5 tests)
 
@@ -30,7 +30,7 @@ directory and returns a `DispatchConfig` object.
 | returns empty object for empty config file | Empty file treated as no-config |
 | loads a valid config file | Standard JSON round-trip |
 | returns empty object for corrupt JSON | Malformed JSON does not throw |
-| loads config with all fields populated | All 6 `DispatchConfig` fields load correctly |
+| loads config with all fields populated | All 8 `DispatchConfig` fields load correctly |
 
 All tests use real filesystem I/O with temporary directories.
 
@@ -69,13 +69,13 @@ Tests the `isValidConfigKey()` type guard function.
 
 | Test | What it verifies |
 |------|------------------|
-| returns true for each valid config key | All 6 keys from `CONFIG_KEYS` are valid |
+| returns true for each valid config key | All 8 keys from `CONFIG_KEYS` are valid |
 | returns false for unknown keys | `"unknown"`, `"dryRun"`, `"noPlan"`, `"verbose"`, `""` all rejected |
 
 The valid config keys are: `provider`, `concurrency`, `source`, `org`,
-`project`, `serverUrl`.
+`project`, `serverUrl`, `planTimeout`, `planRetries`.
 
-### validateConfigValue (7 tests)
+### validateConfigValue (16 tests)
 
 Tests the `validateConfigValue()` function, which returns `null` for valid
 values or an error message string for invalid ones.
@@ -89,6 +89,15 @@ values or an error message string for invalid ones.
 | accepts valid concurrency (positive integer) | `"1"`, `"5"`, `"100"` all valid |
 | rejects non-positive concurrency | `"0"` and `"-1"` return error containing `"positive integer"` |
 | rejects non-integer concurrency | `"1.5"` and `"abc"` both rejected |
+| accepts non-empty string for org, project, serverUrl | `"some-value"` returns `null` for all three keys |
+| rejects empty string for org, project, serverUrl | `""` returns error containing `"must not be empty"` |
+| rejects whitespace-only for org, project, serverUrl | `"   "` returns error containing `"must not be empty"` |
+| accepts valid planTimeout (positive number) | `"1"`, `"10"`, `"1.5"`, `"0.5"` all valid |
+| rejects non-positive planTimeout | `"0"` and `"-5"` return error containing `"positive number"` |
+| rejects non-numeric planTimeout | `"abc"` returns error containing `"positive number"`; `""` rejected |
+| accepts valid planRetries (non-negative integer) | `"0"`, `"1"`, `"5"` all valid |
+| rejects negative planRetries | `"-1"` returns error containing `"non-negative integer"` |
+| rejects non-integer planRetries | `"1.5"` and `"abc"` return error containing `"non-negative integer"` |
 
 **Validation rules by key:**
 
@@ -100,8 +109,10 @@ values or an error message string for invalid ones.
 | `org` | Any non-empty string | Must not be empty or whitespace-only |
 | `project` | Any non-empty string | Must not be empty or whitespace-only |
 | `serverUrl` | Any non-empty string | Must not be empty or whitespace-only |
+| `planTimeout` | `"1"`, `"10"`, `"1.5"`, `"0.5"` | Must parse to positive finite number |
+| `planRetries` | `"0"`, `"1"`, `"5"` | Must parse to non-negative integer |
 
-### parseConfigValue (2 tests)
+### parseConfigValue (4 tests)
 
 Tests the `parseConfigValue()` function, which converts string values to the
 appropriate type for storage.
@@ -110,9 +121,12 @@ appropriate type for storage.
 |------|------------------|
 | converts concurrency to a number | `parseConfigValue("concurrency", "5")` returns `5` (number) |
 | returns string for non-concurrency keys | `parseConfigValue("provider", "copilot")` returns `"copilot"` (string) |
+| converts planTimeout to a number via parseFloat | `parseConfigValue("planTimeout", "10.5")` returns `10.5` (number) |
+| converts planRetries to a number via parseInt | `parseConfigValue("planRetries", "3")` returns `3` (number) |
 
-**Key behavior:** Only `concurrency` is coerced to a number. All other keys
-remain strings.
+**Key behavior:** `concurrency` and `planRetries` are coerced to integers via
+`parseInt`. `planTimeout` is coerced to a float via `parseFloat`. All other
+keys remain strings.
 
 ### merge precedence (5 tests)
 
@@ -132,7 +146,10 @@ production code's field name translation:
 | `serverUrl` | `serverUrl` |
 
 Note that `source` maps to `issueSource` in CLI args -- this is the only
-field where the config key differs from the CLI field name.
+field where the config key differs from the CLI field name. The test's local
+`CONFIG_TO_CLI` mapping covers the original 6 keys; the production code's
+mapping in `src/orchestrator/cli-config.ts:21-30` additionally includes
+`planTimeout` and `planRetries`.
 
 ```mermaid
 flowchart TD
@@ -150,7 +167,7 @@ flowchart TD
 | merge applies to each configurable field | All 5 non-provider fields merge correctly |
 | partially explicit flags still allow config for other fields | Per-field independence |
 
-### handleConfigCommand (9 tests)
+### handleConfigCommand (10 tests)
 
 Tests the `dispatch config` CLI subcommand handler.
 


### PR DESCRIPTION
This pull request updates the CLI documentation to reflect the addition of new configuration and CLI options, clarifies the handling of variadic arguments for `--spec` and `--respec`, and updates line references and descriptions throughout to match recent code changes. It also provides more detail on validation logic, config file schema, and the interplay between CLI flags and configuration defaults.

**CLI and Configuration Option Additions:**

* Added documentation for two new CLI/config options: `--plan-timeout`/`planTimeout` and `--plan-retries`/`planRetries`, including their types, defaults, validation rules, and how to set them via CLI or config file. [[1]](diffhunk://#diff-d5c087fe9786c0e799d10259f98ad2426dbff2c372e452a71a72a7643498315eR136-R166) [[2]](diffhunk://#diff-994ad64d4799c31ba22e07871661c6aa97d08ec6a036995b4c099b983aba6e2eL14-R14) [[3]](diffhunk://#diff-994ad64d4799c31ba22e07871661c6aa97d08ec6a036995b4c099b983aba6e2eL62-R64) [[4]](diffhunk://#diff-994ad64d4799c31ba22e07871661c6aa97d08ec6a036995b4c099b983aba6e2eR120-R125) [[5]](diffhunk://#diff-994ad64d4799c31ba22e07871661c6aa97d08ec6a036995b4c099b983aba6e2eR136-R143) [[6]](diffhunk://#diff-994ad64d4799c31ba22e07871661c6aa97d08ec6a036995b4c099b983aba6e2eR157-R158) [[7]](diffhunk://#diff-994ad64d4799c31ba22e07871661c6aa97d08ec6a036995b4c099b983aba6e2eR183-R184)

**CLI Argument Parsing and Spec Mode:**

* Updated the documentation to describe the variadic parsing behavior for `--spec` and the new `--respec` flag, including how arguments are collected, stored, and validated, and how mutual exclusion is enforced downstream.
* Clarified that spec mode can now be activated by either `--spec` or `--respec`, and described the expanded input types for these flags.

**Config File and Validation Details:**

* Expanded the config file schema and validation documentation to cover the new keys, including specific error messages and parsing rules for `planTimeout` and `planRetries`. [[1]](diffhunk://#diff-994ad64d4799c31ba22e07871661c6aa97d08ec6a036995b4c099b983aba6e2eL93-R95) [[2]](diffhunk://#diff-994ad64d4799c31ba22e07871661c6aa97d08ec6a036995b4c099b983aba6e2eR136-R143) [[3]](diffhunk://#diff-994ad64d4799c31ba22e07871661c6aa97d08ec6a036995b4c099b983aba6e2eL332-R359)
* Updated the config key-to-CLI flag mapping table and provided additional usage examples for the new options. [[1]](diffhunk://#diff-994ad64d4799c31ba22e07871661c6aa97d08ec6a036995b4c099b983aba6e2eR157-R158) [[2]](diffhunk://#diff-994ad64d4799c31ba22e07871661c6aa97d08ec6a036995b4c099b983aba6e2eR183-R184)

**Line Reference and Flow Updates:**

* Updated all code line references in the documentation to match the latest codebase, including references to `parseArgs`, config validation, orchestrator bootstrapping, and error handling. [[1]](diffhunk://#diff-d5c087fe9786c0e799d10259f98ad2426dbff2c372e452a71a72a7643498315eL84-R84) [[2]](diffhunk://#diff-d5c087fe9786c0e799d10259f98ad2426dbff2c372e452a71a72a7643498315eL193-R229) [[3]](diffhunk://#diff-d5c087fe9786c0e799d10259f98ad2426dbff2c372e452a71a72a7643498315eL273-R309) [[4]](diffhunk://#diff-d5c087fe9786c0e799d10259f98ad2426dbff2c372e452a71a72a7643498315eL294-R336) [[5]](diffhunk://#diff-d5c087fe9786c0e799d10259f98ad2426dbff2c372e452a71a72a7643498315eL342-R378) [[6]](diffhunk://#diff-d5c087fe9786c0e799d10259f98ad2426dbff2c372e452a71a72a7643498315eL379-R416) [[7]](diffhunk://#diff-994ad64d4799c31ba22e07871661c6aa97d08ec6a036995b4c099b983aba6e2eL255-R271) [[8]](diffhunk://#diff-994ad64d4799c31ba22e07871661c6aa97d08ec6a036995b4c099b983aba6e2eL286-R302) [[9]](diffhunk://#diff-994ad64d4799c31ba22e07871661c6aa97d08ec6a036995b4c099b983aba6e2eL311-R327) [[10]](diffhunk://#diff-994ad64d4799c31ba22e07871661c6aa97d08ec6a036995b4c099b983aba6e2eL154-R168)
* Updated flowcharts and diagrams to reflect the new `--respec` flag and revised CLI flow.

**Testing and Coverage:**

* Noted that the test suite now covers `--respec` variadic parsing and mutual exclusion with `--spec`.

These changes ensure the documentation accurately reflects the current CLI capabilities and internal logic, making it easier for users and contributors to understand and use the new features.