### PR TITLE
move "orchestrator agent" cause its not an agent

### DIFF
--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -11,17 +11,6 @@ import type { AgentName, Agent, AgentBootOptions } from "./interface.js";
 import { boot as bootPlanner, type PlannerAgent } from "./planner.js";
 import { boot as bootExecutor, type ExecutorAgent } from "./executor.js";
 import { boot as bootSpec, type SpecAgent } from "./spec.js";
-import {
-  boot as bootOrchestrator,
-  type OrchestratorAgent,
-  type RawCliArgs,
-  type UnifiedRunOptions,
-  type RunResult,
-  type DispatchRunOptions,
-  type SpecRunOptions,
-  type FixTestsRunOptions,
-  type FixTestsSummary,
-} from "./orchestrator.js";
 
 type BootFn = (opts: AgentBootOptions) => Promise<Agent>;
 
@@ -58,18 +47,6 @@ export async function bootAgent(
  * Type-safe boot functions for specific agent roles.
  * Prefer these over the generic `bootAgent()` when you know the role at compile time.
  */
-export { bootPlanner, bootExecutor, bootOrchestrator, bootSpec };
-export type {
-  PlannerAgent,
-  ExecutorAgent,
-  OrchestratorAgent,
-  SpecAgent,
-  RawCliArgs,
-  UnifiedRunOptions,
-  RunResult,
-  DispatchRunOptions,
-  SpecRunOptions,
-  FixTestsRunOptions,
-  FixTestsSummary,
-};
+export { bootPlanner, bootExecutor, bootSpec };
+export type { PlannerAgent, ExecutorAgent, SpecAgent };
 export type { AgentName, Agent, AgentBootOptions } from "./interface.js";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@
  */
 
 import { resolve } from "node:path";
-import { bootOrchestrator, type RawCliArgs } from "./agents/index.js";
+import { boot as bootOrchestrator, type RawCliArgs } from "./orchestrator/runner.js";
 import { log } from "./logger.js";
 import { runCleanup } from "./cleanup.js";
 import type { ProviderName } from "./providers/interface.js";

--- a/src/orchestrator/cli-config.ts
+++ b/src/orchestrator/cli-config.ts
@@ -9,7 +9,7 @@
 
 import { log } from "../logger.js";
 import { loadConfig, type DispatchConfig } from "../config.js";
-import type { RawCliArgs } from "../agents/orchestrator.js";
+import type { RawCliArgs } from "./runner.js";
 
 /**
  * Config key → RawCliArgs field mapping.

--- a/src/orchestrator/dispatch-pipeline.ts
+++ b/src/orchestrator/dispatch-pipeline.ts
@@ -17,7 +17,7 @@ import type { ProviderName } from "../providers/interface.js";
 import { bootProvider } from "../providers/index.js";
 import { getDatasource } from "../datasources/index.js";
 import type { DatasourceName, DispatchLifecycleOptions, IssueDetails, IssueFetchOptions } from "../datasources/interface.js";
-import type { OrchestrateRunOptions, DispatchSummary } from "../agents/orchestrator.js";
+import type { OrchestrateRunOptions, DispatchSummary } from "./runner.js";
 import {
   fetchItemsById,
   writeItemsToTempDir,

--- a/src/orchestrator/fix-tests-pipeline.ts
+++ b/src/orchestrator/fix-tests-pipeline.ts
@@ -7,7 +7,7 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { execFile as execFileCb } from "node:child_process";
-import type { FixTestsSummary } from "../agents/orchestrator.js";
+import type { FixTestsSummary } from "./runner.js";
 import type { ProviderName } from "../providers/interface.js";
 import { bootProvider } from "../providers/index.js";
 import { registerCleanup } from "../cleanup.js";

--- a/src/orchestrator/runner.ts
+++ b/src/orchestrator/runner.ts
@@ -1,18 +1,18 @@
 /**
- * Orchestrator — thin coordinator that delegates to extracted pipeline modules.
+ * Runner — thin coordinator that delegates to extracted pipeline modules.
  */
 
 import type { DispatchResult } from "../dispatcher.js";
-import type { AgentBootOptions } from "./interface.js";
+import type { AgentBootOptions } from "../agents/interface.js";
 import type { ProviderName } from "../providers/interface.js";
 import type { DatasourceName } from "../datasources/interface.js";
 import type { SpecOptions, SpecSummary } from "../spec-generator.js";
 import { defaultConcurrency, resolveSource } from "../spec-generator.js";
 import { getDatasource } from "../datasources/index.js";
 import { log } from "../logger.js";
-import { resolveCliConfig } from "../orchestrator/cli-config.js";
-import { runSpecPipeline } from "../orchestrator/spec-pipeline.js";
-import { runDispatchPipeline } from "../orchestrator/dispatch-pipeline.js";
+import { resolveCliConfig } from "./cli-config.js";
+import { runSpecPipeline } from "./spec-pipeline.js";
+import { runDispatchPipeline } from "./dispatch-pipeline.js";
 
 /** Runtime options passed to `orchestrate()`. */
 export interface OrchestrateRunOptions {
@@ -82,13 +82,13 @@ export interface FixTestsRunOptions {
   mode: "fix-tests";
 }
 
-/** Discriminated union of all orchestrator run options. */
+/** Discriminated union of all runner run options. */
 export type UnifiedRunOptions = DispatchRunOptions | SpecRunOptions | FixTestsRunOptions;
 
 /** Unified result type — DispatchSummary or SpecSummary depending on mode. */
 export type RunResult = DispatchSummary | SpecSummary | FixTestsSummary;
 
-/** A booted orchestrator that coordinates dispatch and spec pipelines. */
+/** A booted runner that coordinates dispatch and spec pipelines. */
 export interface OrchestratorAgent {
   orchestrate(opts: OrchestrateRunOptions): Promise<DispatchSummary>;
   generateSpecs(opts: SpecOptions): Promise<SpecSummary>;
@@ -96,11 +96,11 @@ export interface OrchestratorAgent {
   runFromCli(args: RawCliArgs): Promise<RunResult>;
 }
 
-/** Boot an orchestrator agent. */
+/** Boot a runner. */
 export async function boot(opts: AgentBootOptions): Promise<OrchestratorAgent> {
   const { cwd } = opts;
 
-  const agent: OrchestratorAgent = {
+  const runner: OrchestratorAgent = {
     orchestrate: (runOpts) => runDispatchPipeline(runOpts, cwd),
 
     generateSpecs: (specOpts) => runSpecPipeline(specOpts),
@@ -108,14 +108,14 @@ export async function boot(opts: AgentBootOptions): Promise<OrchestratorAgent> {
     async run(opts: UnifiedRunOptions): Promise<RunResult> {
       if (opts.mode === "spec") {
         const { mode: _, ...rest } = opts;
-        return agent.generateSpecs({ ...rest, cwd });
+        return runner.generateSpecs({ ...rest, cwd });
       }
       if (opts.mode === "fix-tests") {
-        const { runFixTestsPipeline } = await import("../orchestrator/fix-tests-pipeline.js");
+        const { runFixTestsPipeline } = await import("./fix-tests-pipeline.js");
         return runFixTestsPipeline({ cwd, provider: "opencode", serverUrl: undefined, verbose: false });
       }
       const { mode: _, ...rest } = opts;
-      return agent.orchestrate(rest);
+      return runner.orchestrate(rest);
     },
 
     async runFromCli(args: RawCliArgs): Promise<RunResult> {
@@ -140,7 +140,7 @@ export async function boot(opts: AgentBootOptions): Promise<OrchestratorAgent> {
       }
 
       if (m.fixTests) {
-        const { runFixTestsPipeline } = await import("../orchestrator/fix-tests-pipeline.js");
+        const { runFixTestsPipeline } = await import("./fix-tests-pipeline.js");
         return runFixTestsPipeline({ cwd: m.cwd, provider: m.provider, serverUrl: m.serverUrl, verbose: m.verbose });
       }
 
@@ -193,7 +193,7 @@ export async function boot(opts: AgentBootOptions): Promise<OrchestratorAgent> {
     },
   };
 
-  return agent;
+  return runner;
 }
 
-export { parseIssueFilename } from "../orchestrator/datasource-helpers.js";
+export { parseIssueFilename } from "./datasource-helpers.js";

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -31,8 +31,8 @@ vi.mock("../cleanup.js", () => ({
   registerCleanup: vi.fn(),
 }));
 
-vi.mock("../agents/index.js", () => ({
-  bootOrchestrator: vi.fn().mockReturnValue(new Promise(() => {})),
+vi.mock("../orchestrator/runner.js", () => ({
+  boot: vi.fn().mockReturnValue(new Promise(() => {})),
 }));
 
 import { parseArgs } from "../cli.js";

--- a/src/tests/orchestrator.test.ts
+++ b/src/tests/orchestrator.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { readFile, writeFile, mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { parseIssueFilename } from "../agents/orchestrator.js";
+import { parseIssueFilename } from "../orchestrator/runner.js";
 import { markTaskComplete, type Task } from "../parser.js";
 import type { Datasource, IssueDetails, IssueFetchOptions } from "../datasources/interface.js";
 

--- a/src/tests/respec-routing.test.ts
+++ b/src/tests/respec-routing.test.ts
@@ -54,7 +54,7 @@ vi.mock("../orchestrator/dispatch-pipeline.js", () => ({
 
 // ─── Imports (AFTER vi.mock calls) ──────────────────────────────────
 
-import { boot, type RawCliArgs } from "../agents/orchestrator.js";
+import { boot, type RawCliArgs } from "../orchestrator/runner.js";
 import { log } from "../logger.js";
 import { resolveCliConfig } from "../orchestrator/cli-config.js";
 import { resolveSource } from "../spec-generator.js";


### PR DESCRIPTION
This pull request refactors the orchestrator agent by moving its implementation from `src/agents/orchestrator.ts` to `src/orchestrator/runner.ts`, and updates all related imports and type references throughout the codebase. The main goal is to improve code organization by separating orchestrator logic from the generic agents module, making the codebase more modular and maintainable.

Key changes include:

**Orchestrator Refactor and Relocation:**

- Renamed and moved `src/agents/orchestrator.ts` to `src/orchestrator/runner.ts`, updating the agent's name from "orchestrator" to "runner" in comments and documentation for clarity and consistency. [[1]](diffhunk://#diff-e0d2a6cca1e23b0055dedb242959b87e9811d935952829bc75972711e0219e97L2-R15) [[2]](diffhunk://#diff-e0d2a6cca1e23b0055dedb242959b87e9811d935952829bc75972711e0219e97L85-R118)
- Updated all imports and type references in the codebase to point to the new `src/orchestrator/runner.ts` location, including types like `RawCliArgs`, `OrchestrateRunOptions`, and `FixTestsSummary`. [[1]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL13-R13) [[2]](diffhunk://#diff-5cb639f0387d7b5912233f374353606c0d0caf6b3f6c226103784feeb54ae490L12-R12) [[3]](diffhunk://#diff-ea7caeb0d619694ac34e0a741fa0d61063ee251b763eba197784980b3bb2bf66L20-R20) [[4]](diffhunk://#diff-723915a41be7193544d5c919180a85bfe64b0f84eb8a0a305359911721c64d33L10-R10) [[5]](diffhunk://#diff-ec3f4bff72306f202997215740aa138515c6ccc91fb79698607945de5f5cb7a9L5-R5) [[6]](diffhunk://#diff-83bd36ab9aa0875eec0219f00d5febab689c4f3e0d0c7bbff43656e5741bec35L57-R57) [[7]](diffhunk://#diff-da0fd276eacaf04add66795543a31386dd65427f66190674039eed7811409a84L34-R35)

**Agents Module Simplification:**

- Removed all orchestrator-specific exports (functions and types) from `src/agents/index.ts`, so it now only exports planner, executor, and spec agent boot functions and types. [[1]](diffhunk://#diff-385b03920fdf8990d7459ac86273777e41422e5ca51983169e841e472f303aaaL14-L24) [[2]](diffhunk://#diff-385b03920fdf8990d7459ac86273777e41422e5ca51983169e841e472f303aaaL61-R51)

**Test and Internal Import Updates:**

- Updated all test files and internal modules to use the new `runner` module for orchestrator functionality, ensuring consistency across the codebase. [[1]](diffhunk://#diff-da0fd276eacaf04add66795543a31386dd65427f66190674039eed7811409a84L34-R35) [[2]](diffhunk://#diff-ec3f4bff72306f202997215740aa138515c6ccc91fb79698607945de5f5cb7a9L5-R5) [[3]](diffhunk://#diff-83bd36ab9aa0875eec0219f00d5febab689c4f3e0d0c7bbff43656e5741bec35L57-R57)

**Internal Import Path Corrections:**

- Changed relative import paths within the runner implementation and related pipelines to use the new module structure (e.g., `./cli-config.js` instead of `../orchestrator/cli-config.js`). [[1]](diffhunk://#diff-e0d2a6cca1e23b0055dedb242959b87e9811d935952829bc75972711e0219e97L2-R15) [[2]](diffhunk://#diff-e0d2a6cca1e23b0055dedb242959b87e9811d935952829bc75972711e0219e97L85-R118) [[3]](diffhunk://#diff-e0d2a6cca1e23b0055dedb242959b87e9811d935952829bc75972711e0219e97L143-R143) [[4]](diffhunk://#diff-e0d2a6cca1e23b0055dedb242959b87e9811d935952829bc75972711e0219e97L196-R199)

These changes improve code modularity, clarify the separation of concerns between agents and orchestrator logic, and make future maintenance and extension easier.