### PR TITLE
fix: detect actual default model in copilot provider

### DIFF
--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -32,24 +32,18 @@ export async function boot(opts?: ProviderBootOptions): Promise<ProviderInstance
     throw err;
   }
 
-  // ── Retrieve the active model (best-effort) ──────────────────
+  // Model is detected lazily after the first session is created
   let model: string | undefined;
-  try {
-    const models = await client.listModels();
-    if (models.length > 0) {
-      model = models[0].id;
-      log.debug(`Detected model: ${model}`);
-    }
-  } catch (err) {
-    log.debug(`Failed to retrieve model from Copilot: ${log.formatErrorChain(err)}`);
-  }
+  let modelDetected = false;
 
   // Track live sessions for prompt routing and cleanup
   const sessions = new Map<string, CopilotSession>();
 
   return {
     name: "copilot",
-    model,
+    get model() {
+      return model;
+    },
 
     async createSession(): Promise<string> {
       log.debug("Creating Copilot session...");
@@ -57,6 +51,21 @@ export async function boot(opts?: ProviderBootOptions): Promise<ProviderInstance
         const session = await client.createSession({ onPermissionRequest: approveAll });
         sessions.set(session.sessionId, session);
         log.debug(`Session created: ${session.sessionId}`);
+
+        // Detect actual default model from the first session (best-effort, once only)
+        if (!modelDetected) {
+          modelDetected = true;
+          try {
+            const result = await session.rpc.model.getCurrent();
+            if (result.modelId) {
+              model = result.modelId;
+              log.debug(`Detected model: ${model}`);
+            }
+          } catch (err) {
+            log.debug(`Failed to detect model from session: ${log.formatErrorChain(err)}`);
+          }
+        }
+
         return session.sessionId;
       } catch (err) {
         log.debug(`Session creation failed: ${log.formatErrorChain(err)}`);


### PR DESCRIPTION
## Summary

- fix: detect actual default model in copilot provider

## Tasks

- [x] Remove the `listModels()` model-detection block from the `boot()` function in `src/providers/copilot.ts`. Replace it with lazy model detection: after the first session is created in `createSession()`, call `session.rpc.model.getCurrent()` to get the actual model ID and cache it in the closure's `model` variable. Expose `model` via a getter on the returned provider object so it updates transparently. Ensure subsequent `createSession()` calls skip the model detection (only detect once). Commit with message: `fix: detect actual default model in copilot provider`.
- [x] Verify that the TUI and header rendering in `src/orchestrator/dispatch-pipeline.ts` and `src/orchestrator/spec-pipeline.ts` correctly reflect the lazily-populated model. If `instance.model` is read only once at boot (before any session), consider updating the TUI state after the first session creation. Check that `src/format.ts` and `src/tui.ts` handle `undefined` model gracefully (they already do with conditional checks). Make any minimal adjustments needed so the model appears in the UI once detected.

Closes #58