### PR TITLE
ci: add Windows runner to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Closes #214

Adds `windows-latest` to the CI workflow's OS matrix so that Windows-specific regressions (CRLF handling, path separators, `.cmd` shim resolution) are caught before merging.

#### Changes
- Added a `strategy` block to the `test` job in `.github/workflows/ci.yml` with `fail-fast: false` and a `matrix.os` containing `ubuntu-latest` and `windows-latest`
- Changed `runs-on` from the hardcoded `ubuntu-latest` to `${{ matrix.os }}`

All existing steps remain unchanged — the test suite now runs on both Linux and Windows in parallel.