### PR TITLE
Fix CRLF normalization gap in markTaskComplete for Windows

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -120,7 +120,9 @@ export async function parseTaskFile(filePath: string): Promise<TaskFile> {
  */
 export async function markTaskComplete(task: Task): Promise<void> {
   const content = await readFile(task.file, "utf-8");
-  const lines = content.split("\n");
+  const eol = content.includes("\r\n") ? "\r\n" : "\n";
+  const normalized = content.replace(/\r\n/g, "\n");
+  const lines = normalized.split("\n");
   const lineIndex = task.line - 1;
 
   if (lineIndex < 0 || lineIndex >= lines.length) {
@@ -139,7 +141,7 @@ export async function markTaskComplete(task: Task): Promise<void> {
   }
 
   lines[lineIndex] = updated;
-  await writeFile(task.file, lines.join("\n"), "utf-8");
+  await writeFile(task.file, lines.join(eol), "utf-8");
 }
 
 /**

--- a/src/tests/parser.test.ts
+++ b/src/tests/parser.test.ts
@@ -726,6 +726,46 @@ describe("markTaskComplete", () => {
 
     await expect(markTaskComplete(task)).rejects.toThrow("does not match");
   });
+
+  it("preserves CRLF line endings when marking complete", async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "dispatch-test-"));
+    const filePath = join(tmpDir, "tasks.md");
+    const md = "# Tasks\r\n- [ ] First task\r\n- [ ] Second task\r\n";
+    await writeFile(filePath, md, "utf-8");
+
+    const task: Task = {
+      index: 0,
+      text: "First task",
+      line: 2,
+      raw: "- [ ] First task",
+      file: filePath,
+    };
+
+    await markTaskComplete(task);
+
+    const updated = await readFile(filePath, "utf-8");
+    expect(updated).toBe("# Tasks\r\n- [x] First task\r\n- [ ] Second task\r\n");
+  });
+
+  it("preserves LF line endings when marking complete", async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "dispatch-test-"));
+    const filePath = join(tmpDir, "tasks.md");
+    const md = "# Tasks\n- [ ] First task\n- [ ] Second task\n";
+    await writeFile(filePath, md, "utf-8");
+
+    const task: Task = {
+      index: 0,
+      text: "First task",
+      line: 2,
+      raw: "- [ ] First task",
+      file: filePath,
+    };
+
+    await markTaskComplete(task);
+
+    const updated = await readFile(filePath, "utf-8");
+    expect(updated).toBe("# Tasks\n- [x] First task\n- [ ] Second task\n");
+  });
 });
 
 // ─── buildTaskContext ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #210 — `markTaskComplete` was silently converting CRLF line endings to LF when rewriting task files on Windows, corrupting the line-ending style of the original file.

## Problem

The `markTaskComplete` function in `src/parser.ts` split file content on `\n` and joined lines back with `\n`, discarding any `\r\n` (CRLF) line endings present in the original file. On Windows, where files commonly use CRLF, this caused silent line-ending drift every time a task was marked complete.

## Changes

### `src/parser.ts`
- Detect the original EOL style (`\r\n` or `\n`) before processing
- Normalize `\r\n` to `\n` before splitting lines, ensuring consistent parsing
- Restore the original EOL style when joining lines for write-back

### `src/tests/parser.test.ts`
- Added test verifying CRLF line endings are preserved after marking a task complete
- Added test verifying LF line endings remain unchanged after marking a task complete