### PR TITLE
Simplify --spec and --respec: update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ dispatch --spec 42,43
 | Mode | Flag | Description |
 |------|------|-------------|
 | **Dispatch** | *(default)* | Plan and execute tasks; manage full git lifecycle |
-| **Spec generation** | `--spec` / `--respec` | Convert issues into structured markdown spec files |
+| **Spec generation** | `--spec` | Convert issues into structured markdown spec files |
 | **Fix tests** | `--fix-tests` | Detect and auto-fix failing tests via AI |
 
 ## Task files
@@ -215,8 +215,7 @@ Config is stored at `.dispatch/config.json` (relative to the working directory w
 
 | Option | Description |
 |--------|-------------|
-| `--spec <values...>` | Issue numbers, glob pattern, or description. Activates spec mode. |
-| `--respec [values...]` | Regenerate existing specs. Pass no args to regenerate all. |
+| `--spec [values...]` | Issue numbers, glob pattern, or description. Activates spec mode. Pass no args to regenerate all existing specs. |
 | `--source <name>` | Datasource override (auto-detected if omitted) |
 | `--output-dir <dir>` | Output directory for spec files (default: `.dispatch/specs`) |
 | `--org <url>` | Azure DevOps organization URL (required for `azdevops`) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,7 +64,7 @@ C4Context
     Rel(dev, cli, "invokes")
     Rel(cli, config, "config subcommand")
     Rel(cli, runner, "delegates pipeline execution")
-    Rel(runner, spec_pipe, "--spec / --respec")
+    Rel(runner, spec_pipe, "--spec")
     Rel(runner, dispatch_pipe, "default mode")
     Rel(runner, fix_pipe, "--fix-tests (dynamic import)")
     Rel(spec_pipe, ds_layer, "fetch, update, create")
@@ -92,7 +92,7 @@ enforced by the orchestrator, not the argument parser.
 
 | Mode | Trigger | Purpose | Detail page |
 |------|---------|---------|-------------|
-| **Spec generation** | `--spec` or `--respec` | Convert issues into structured markdown specs | [Spec generation](spec-generation/overview.md) |
+| **Spec generation** | `--spec` | Convert issues into structured markdown specs | [Spec generation](spec-generation/overview.md) |
 | **Dispatch** | Default (no mode flag) | Plan and execute tasks, commit, push, open PRs | [Planning & dispatch](planning-and-dispatch/overview.md) |
 | **Fix tests** | `--fix-tests` | Detect failing tests and prompt AI to fix them | [CLI orchestration](cli-orchestration/overview.md) |
 

--- a/docs/cli-orchestration/cli.md
+++ b/docs/cli-orchestration/cli.md
@@ -142,14 +142,13 @@ frameworks handle automatically:
 
 ### Spec mode options
 
-Spec mode is activated by passing `--spec` or `--respec`. When active, the
-issue IDs are not required and the dispatch-specific flags (`--dry-run`,
-`--no-plan`, `--concurrency`) are ignored.
+Spec mode is activated by passing `--spec`. When active, the issue IDs are not
+required and the dispatch-specific flags (`--dry-run`, `--no-plan`,
+`--concurrency`) are ignored.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--spec <values...>` | string (one or more) | *none* | Comma-separated issue numbers, multiple space-separated args, glob pattern for local `.md` files, or inline text description. Activates spec mode. See [issue IDs vs glob patterns](configuration.md#the---spec-flag-issue-ids-vs-glob-patterns). |
-| `--respec [values...]` | string (zero or more) | *none* | Regenerate existing specs. Accepts the same value types as `--spec` (issue numbers, glob, multiple args), or can be passed with no arguments to regenerate all existing specs. Uses variadic collection -- consumes all subsequent non-flag arguments. An empty invocation (`--respec` with no args or immediately followed by another flag) produces an empty array. |
+| `--spec [values...]` | string (zero or more) | *none* | Comma-separated issue numbers, multiple space-separated args, glob pattern for local `.md` files, or inline text description. Activates spec mode. Pass with no arguments to regenerate all existing specs. See [issue IDs vs glob patterns](configuration.md#the---spec-flag-issue-ids-vs-glob-patterns). |
 | `--source <name>` | string | *auto-detected* | Datasource: `github`, `azdevops`, or `md`. Auto-detected from `git remote get-url origin` if omitted. See [datasource detection](configuration.md#auto-detection-from-git-remote), [Datasource Overview](../datasource-system/overview.md), and individual datasource docs: [GitHub](../datasource-system/github-datasource.md), [Azure DevOps](../datasource-system/azdevops-datasource.md), [Markdown](../datasource-system/markdown-datasource.md). |
 | `--org <url>` | string | *none* | Azure DevOps organization URL (e.g., `https://dev.azure.com/myorg`). Required when `--source azdevops`. |
 | `--project <name>` | string | *none* | Azure DevOps project name. Required when `--source azdevops`. |
@@ -163,11 +162,11 @@ issue IDs are not required and the dispatch-specific flags (`--dry-run`,
 
 Fix-tests mode is activated by passing `--fix-tests`. It runs the project's
 test suite and uses an AI agent to fix any failures. This mode is mutually
-exclusive with `--spec`, `--respec`, and positional issue IDs.
+exclusive with `--spec` and positional issue IDs.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--fix-tests` | boolean | `false` | Activate fix-tests mode. Cannot be combined with `--spec`, `--respec`, or positional issue IDs. |
+| `--fix-tests` | boolean | `false` | Activate fix-tests mode. Cannot be combined with `--spec` or positional issue IDs. |
 | `--test-timeout <min>` | float | `5` | Test timeout in minutes (shared with dispatch mode) |
 | `--provider <name>` | string | `"opencode"` | AI agent backend (shared with dispatch mode) |
 | `--server-url <url>` | string | *none* | Connect to a running provider server (shared with dispatch mode) |
@@ -185,35 +184,32 @@ the pipeline aborts with an error suggesting `--source` be specified explicitly.
 See the [Spec Generation overview](../spec-generation/overview.md) for the
 full detection logic.
 
-#### `--spec` and `--respec` variadic parsing
+#### `--spec` variadic parsing
 
-Both `--spec` and `--respec` use variadic collection loops
-(`src/cli.ts:141-150` and `src/cli.ts:151-160`) that consume all subsequent
-non-flag arguments (arguments not starting with `--`). The collection stops
-when the next `--`-prefixed flag is encountered or the argument list is
-exhausted.
+`--spec` uses a variadic collection loop (`src/cli.ts:141-150`) that consumes
+all subsequent non-flag arguments (arguments not starting with `--`). The
+collection stops when the next `--`-prefixed flag is encountered or the
+argument list is exhausted.
 
 - **Single value**: stored as a string (e.g., `--spec 42` produces `"42"`)
 - **Multiple values**: stored as an array (e.g., `--spec 42 43` produces
   `["42", "43"]`)
 - **Empty** (no args before next flag or end of input): produces an empty
-  array for `--respec` (e.g., `--respec --verbose` produces `[]`); `--spec`
-  with no arguments also produces an empty array.
+  array (e.g., `--spec --verbose` produces `[]`), triggering regeneration
+  of all existing specs.
 
-The `--spec`, `--respec`, and `--fix-tests` flags are mutually exclusive.
-Mutual exclusion is enforced downstream by the runner
-(`src/orchestrator/runner.ts:153-163`), which checks for multiple mode flags
-and produces an error.
+The `--spec` and `--fix-tests` flags are mutually exclusive. Mutual exclusion
+is enforced downstream by the runner (`src/orchestrator/runner.ts`), which
+checks for multiple mode flags and produces an error.
 
 Examples:
 
 ```bash
-dispatch --respec                        # respec = []     (regenerate all)
-dispatch --respec 42                     # respec = "42"   (single issue)
-dispatch --respec 42 43 44              # respec = ["42", "43", "44"]
-dispatch --respec "specs/*.md"          # respec = "specs/*.md"
-dispatch --respec --verbose             # respec = []     (empty, --verbose consumed separately)
-dispatch --spec 1,2 --respec 3,4       # spec = "1,2", respec = "3,4" (both set — rejected by runner)
+dispatch --spec                          # spec = []      (regenerate all existing specs)
+dispatch --spec 42                       # spec = "42"    (single issue)
+dispatch --spec 42 43 44                # spec = ["42", "43", "44"]
+dispatch --spec "specs/*.md"            # spec = "specs/*.md"
+dispatch --spec --verbose               # spec = []      (empty, --verbose consumed separately)
 dispatch --fix-tests                     # fix-tests mode
 dispatch --fix-tests --test-timeout 10   # fix-tests with custom timeout
 ```
@@ -384,7 +380,6 @@ flowchart TD
     L --> M{"Mode?"}
     M -->|--fix-tests| N["Fix-tests pipeline"]
     M -->|--spec| O["Spec pipeline"]
-    M -->|--respec| O
     M -->|default| P["Dispatch pipeline"]
     N --> Q["Summary"]
     O --> Q

--- a/docs/cli-orchestration/orchestrator.md
+++ b/docs/cli-orchestration/orchestrator.md
@@ -13,7 +13,7 @@ The orchestrator exposes two entry points from the CLI:
 1. **`runFromCli(args)`**: Called by the CLI after `bootOrchestrator()`. This
    method first calls [`resolveCliConfig()`](configuration.md#three-tier-configuration-precedence)
    to merge config-file defaults with CLI flags, then routes to either the
-   spec pipeline (if `--spec` or `--respec` is present; see [Spec Generation](../spec-generation/overview.md)) or the dispatch pipeline.
+   spec pipeline (if `--spec` is present; see [Spec Generation](../spec-generation/overview.md)) or the dispatch pipeline.
 
 2. **`orchestrate()`**: The core dispatch function that accepts an
    `OrchestrateRunOptions` object and executes the dispatch pipeline


### PR DESCRIPTION
## Summary

Updates all documentation to reflect the consolidation of `--respec` into `--spec`, as part of #202.

## Changes

- **README.md**: Removed `--respec` row from the flag table; updated `--spec` description to document zero-argument regeneration behavior
- **docs/architecture.md**: Updated Mermaid diagram label from `--spec / --respec` to `--spec`; removed `--respec` from the pipeline trigger table
- **docs/cli-orchestration/cli.md**: Removed `--respec` flag row; updated `--spec` to `[values...]` (optional variadic); rewrote variadic parsing section for `--spec` only; updated mutual exclusion text; replaced `--respec` examples with `--spec` zero-argument equivalents; removed `--respec` branch from Mermaid flowchart
- **docs/cli-orchestration/orchestrator.md**: Updated spec pipeline activation text to reference only `--spec`

## Context

This is the documentation portion of simplifying the CLI surface by eliminating the redundant `--respec` flag. The `--spec` flag now supports being called with no arguments to regenerate all existing specs, which was previously the sole purpose of `--respec`.

Closes #202 (partially — code changes pending)