### PR TITLE
Remove direct issue closing — let PR merge close issues via auto-close references

### DIFF
--- a/src/orchestrator/datasource-helpers.ts
+++ b/src/orchestrator/datasource-helpers.ts
@@ -4,9 +4,8 @@ import { tmpdir } from "node:os";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { log } from "../helpers/logger.js";
-import { getDatasource, detectDatasource } from "../datasources/index.js";
 import type { Datasource, DatasourceName, IssueDetails, IssueFetchOptions } from "../datasources/interface.js";
-import type { Task, TaskFile } from "../parser.js";
+import type { Task } from "../parser.js";
 import type { DispatchResult } from "../dispatcher.js";
 import { slugify, MAX_SLUG_LENGTH } from "../helpers/slugify.js";
 
@@ -83,59 +82,6 @@ export async function writeItemsToTempDir(items: IssueDetails[]): Promise<WriteI
   });
 
   return { files, issueDetailsByFile };
-}
-
-/**
- * For each spec file where all tasks completed successfully, extract the
- * issue number from the filename (`<id>-<slug>.md`) and close the originating
- * issue on the tracker.
- */
-export async function closeCompletedSpecIssues(
-  taskFiles: TaskFile[],
-  results: DispatchResult[],
-  cwd: string,
-  source?: DatasourceName,
-  org?: string,
-  project?: string,
-  workItemType?: string,
-): Promise<void> {
-  // Resolve the datasource — use explicit source or auto-detect
-  let datasourceName = source;
-  if (!datasourceName) {
-    datasourceName = await detectDatasource(cwd) ?? undefined;
-  }
-  if (!datasourceName) return;
-
-  const datasource = getDatasource(datasourceName);
-
-  // Build a set of tasks that succeeded
-  const succeededTasks = new Set(
-    results.filter((r) => r.success).map((r) => r.task)
-  );
-
-  const fetchOpts: IssueFetchOptions = { cwd, org, project, workItemType };
-
-  for (const taskFile of taskFiles) {
-    const fileTasks = taskFile.tasks;
-    if (fileTasks.length === 0) continue;
-
-    // Only close if every task in this file completed successfully
-    const allSucceeded = fileTasks.every((t) => succeededTasks.has(t));
-    if (!allSucceeded) continue;
-
-    // Extract the issue ID from the filename: "<id>-<slug>.md"
-    const parsed = parseIssueFilename(taskFile.path);
-    if (!parsed) continue;
-
-    const { issueId } = parsed;
-    const filename = basename(taskFile.path);
-    try {
-      await datasource.close(issueId, fetchOpts);
-      log.success(`Closed issue #${issueId} (all tasks in ${filename} completed)`);
-    } catch (err) {
-      log.warn(`Could not close issue #${issueId}: ${log.formatErrorChain(err)}`);
-    }
-  }
 }
 
 /**

--- a/src/orchestrator/dispatch-pipeline.ts
+++ b/src/orchestrator/dispatch-pipeline.ts
@@ -26,7 +26,6 @@ import type { OrchestrateRunOptions, DispatchSummary } from "./runner.js";
 import {
   fetchItemsById,
   writeItemsToTempDir,
-  closeCompletedSpecIssues,
   parseIssueFilename,
   buildPrBody,
   buildPrTitle,
@@ -713,14 +712,7 @@ export async function runDispatchPipeline(
       }
     }
 
-    // ── 6. Close originating issues for completed spec files ────
-    try {
-      await closeCompletedSpecIssues(taskFiles, results, cwd, source, org, project, workItemType);
-    } catch (err) {
-      log.warn(`Could not close completed spec issues: ${log.formatErrorChain(err)}`);
-    }
-
-    // ── 7. Cleanup ──────────────────────────────────────────────
+    // ── 6. Cleanup ──────────────────────────────────────────────
     // Per-worktree resources are cleaned up inside processIssueFile.
     // Shared resources (when !useWorktrees) are cleaned up here.
     await commitAgent?.cleanup();

--- a/src/tests/datasource-helpers.test.ts
+++ b/src/tests/datasource-helpers.test.ts
@@ -32,29 +32,17 @@ vi.mock("node:util", () => ({
   promisify: () => mockExecFile,
 }));
 
-const { mockGetDatasource, mockDetectDatasource } = vi.hoisted(() => ({
-  mockGetDatasource: vi.fn(),
-  mockDetectDatasource: vi.fn(),
-}));
-
-vi.mock("../datasources/index.js", () => ({
-  getDatasource: mockGetDatasource,
-  detectDatasource: mockDetectDatasource,
-}));
-
 // Must import log AFTER vi.mock to get the mocked version
 import { log } from "../helpers/logger.js";
 
 beforeEach(() => {
   mockExecFile.mockReset();
-  mockGetDatasource.mockReset();
-  mockDetectDatasource.mockReset();
 });
 import {
   parseIssueFilename,
   fetchItemsById,
   writeItemsToTempDir,
-  closeCompletedSpecIssues,
+
   buildPrBody,
   buildPrTitle,
   buildFeaturePrTitle,
@@ -753,136 +741,6 @@ describe("buildFeaturePrBody", () => {
     const issues = [createIssueDetails({ number: "10" })];
     const body = buildFeaturePrBody(issues, [], [], "github");
     expect(body).not.toContain("## Tasks");
-  });
-});
-
-// ─── closeCompletedSpecIssues ────────────────────────────────────────
-
-describe("closeCompletedSpecIssues", () => {
-  /** Create a Task fixture. */
-  function createCloseTask(overrides?: Partial<Task>): Task {
-    return {
-      index: 0,
-      text: "Implement feature",
-      line: 1,
-      raw: "- [ ] Implement feature",
-      file: "/tmp/dispatch-abc/42-feature.md",
-      ...overrides,
-    };
-  }
-
-  function createTaskFile(path: string, tasks: Task[]) {
-    return { path, tasks, content: "" };
-  }
-
-  function createCloseDatasource(overrides?: Partial<Datasource>): Datasource {
-    return {
-      name: "github",
-      supportsGit: vi.fn<Datasource["supportsGit"]>().mockReturnValue(true),
-      list: vi.fn<Datasource["list"]>().mockResolvedValue([]),
-      fetch: vi.fn<Datasource["fetch"]>().mockResolvedValue({} as IssueDetails),
-      update: vi.fn<Datasource["update"]>().mockResolvedValue(undefined),
-      close: vi.fn<Datasource["close"]>().mockResolvedValue(undefined),
-      create: vi.fn<Datasource["create"]>().mockResolvedValue({} as IssueDetails),
-      getDefaultBranch: vi.fn<Datasource["getDefaultBranch"]>().mockResolvedValue("main"),
-      getUsername: vi.fn<Datasource["getUsername"]>().mockResolvedValue("testuser"),
-      buildBranchName: vi.fn<Datasource["buildBranchName"]>().mockReturnValue("testuser/dispatch/1"),
-      createAndSwitchBranch: vi.fn<Datasource["createAndSwitchBranch"]>().mockResolvedValue(undefined),
-      switchBranch: vi.fn<Datasource["switchBranch"]>().mockResolvedValue(undefined),
-      pushBranch: vi.fn<Datasource["pushBranch"]>().mockResolvedValue(undefined),
-      commitAllChanges: vi.fn<Datasource["commitAllChanges"]>().mockResolvedValue(undefined),
-      createPullRequest: vi.fn<Datasource["createPullRequest"]>().mockResolvedValue(""),
-      ...overrides,
-    };
-  }
-
-  it("closes issue when all tasks succeeded", async () => {
-    const task = createCloseTask({ file: "/tmp/42-bug-fix.md" });
-    const taskFile = createTaskFile("/tmp/42-bug-fix.md", [task]);
-    const results: DispatchResult[] = [{ task, success: true }];
-    const ds = createCloseDatasource();
-    mockGetDatasource.mockReturnValue(ds);
-
-    await closeCompletedSpecIssues([taskFile], results, "/tmp", "github");
-
-    expect(ds.close).toHaveBeenCalledWith("42", { cwd: "/tmp", org: undefined, project: undefined });
-  });
-
-  it("does not close when some tasks failed", async () => {
-    const task1 = createCloseTask({ index: 0, file: "/tmp/42-feat.md" });
-    const task2 = createCloseTask({ index: 1, text: "Second task", file: "/tmp/42-feat.md" });
-    const taskFile = createTaskFile("/tmp/42-feat.md", [task1, task2]);
-    const results: DispatchResult[] = [
-      { task: task1, success: true },
-      { task: task2, success: false, error: "failed" },
-    ];
-    const ds = createCloseDatasource();
-    mockGetDatasource.mockReturnValue(ds);
-
-    await closeCompletedSpecIssues([taskFile], results, "/tmp", "github");
-
-    expect(ds.close).not.toHaveBeenCalled();
-  });
-
-  it("auto-detects datasource when source is undefined", async () => {
-    const task = createCloseTask({ file: "/tmp/42-bug.md" });
-    const taskFile = createTaskFile("/tmp/42-bug.md", [task]);
-    const results: DispatchResult[] = [{ task, success: true }];
-    const ds = createCloseDatasource();
-    mockDetectDatasource.mockResolvedValue("github");
-    mockGetDatasource.mockReturnValue(ds);
-
-    await closeCompletedSpecIssues([taskFile], results, "/tmp");
-
-    expect(mockDetectDatasource).toHaveBeenCalledWith("/tmp");
-    expect(ds.close).toHaveBeenCalled();
-  });
-
-  it("returns early when source is undefined and auto-detect fails", async () => {
-    const task = createCloseTask({ file: "/tmp/42-bug.md" });
-    const taskFile = createTaskFile("/tmp/42-bug.md", [task]);
-    const results: DispatchResult[] = [{ task, success: true }];
-    mockDetectDatasource.mockResolvedValue(null);
-
-    await closeCompletedSpecIssues([taskFile], results, "/tmp");
-
-    expect(mockGetDatasource).not.toHaveBeenCalled();
-  });
-
-  it("skips files that don't match <id>-<slug>.md pattern", async () => {
-    const task = createCloseTask({ file: "/tmp/notes.md" });
-    const taskFile = createTaskFile("/tmp/notes.md", [task]);
-    const results: DispatchResult[] = [{ task, success: true }];
-    const ds = createCloseDatasource();
-    mockGetDatasource.mockReturnValue(ds);
-
-    await closeCompletedSpecIssues([taskFile], results, "/tmp", "github");
-
-    expect(ds.close).not.toHaveBeenCalled();
-  });
-
-  it("skips files with no tasks", async () => {
-    const taskFile = createTaskFile("/tmp/42-empty.md", []);
-    const ds = createCloseDatasource();
-    mockGetDatasource.mockReturnValue(ds);
-
-    await closeCompletedSpecIssues([taskFile], [], "/tmp", "github");
-
-    expect(ds.close).not.toHaveBeenCalled();
-  });
-
-  it("logs warning when close throws", async () => {
-    const task = createCloseTask({ file: "/tmp/42-bug.md" });
-    const taskFile = createTaskFile("/tmp/42-bug.md", [task]);
-    const results: DispatchResult[] = [{ task, success: true }];
-    const ds = createCloseDatasource({
-      close: vi.fn<Datasource["close"]>().mockRejectedValue(new Error("close failed")),
-    });
-    mockGetDatasource.mockReturnValue(ds);
-
-    await closeCompletedSpecIssues([taskFile], results, "/tmp", "github");
-
-    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("close failed"));
   });
 });
 

--- a/src/tests/dispatch-pipeline.test.ts
+++ b/src/tests/dispatch-pipeline.test.ts
@@ -176,7 +176,6 @@ vi.mock("../orchestrator/datasource-helpers.js", () => ({
       acceptanceCriteria: "",
     }]]),
   }),
-  closeCompletedSpecIssues: vi.fn().mockResolvedValue(undefined),
   parseIssueFilename: vi.fn().mockReturnValue({ issueId: "1", slug: "test" }),
   buildPrBody: vi.fn().mockResolvedValue("PR body"),
   buildPrTitle: vi.fn().mockResolvedValue("PR title"),
@@ -208,7 +207,7 @@ import { createTui } from "../tui.js";
 import { createWorktree, removeWorktree, worktreeName, generateFeatureBranchName } from "../helpers/worktree.js";
 import { registerCleanup } from "../helpers/cleanup.js";
 import { parseTaskFile } from "../parser.js";
-import { fetchItemsById, writeItemsToTempDir, parseIssueFilename, closeCompletedSpecIssues, getBranchDiff, squashBranchCommits, buildFeaturePrTitle, buildFeaturePrBody } from "../orchestrator/datasource-helpers.js";
+import { fetchItemsById, writeItemsToTempDir, parseIssueFilename, getBranchDiff, squashBranchCommits, buildFeaturePrTitle, buildFeaturePrBody } from "../orchestrator/datasource-helpers.js";
 import { execFile } from "node:child_process";
 import { bootProvider } from "../providers/index.js";
 import { boot as bootPlannerBoot } from "../agents/planner.js";
@@ -1631,23 +1630,6 @@ describe("error-path handling", () => {
     await expect(
       runDispatchPipeline(baseOpts({ noPlan: true }), "/tmp/test"),
     ).rejects.toThrow("network failure");
-  });
-
-  it("continues and logs warning when closeCompletedSpecIssues rejects", async () => {
-    vi.mocked(closeCompletedSpecIssues).mockRejectedValueOnce(
-      new Error("close failed"),
-    );
-
-    const result = await runDispatchPipeline(
-      baseOpts({ noPlan: true }),
-      "/tmp/test",
-    );
-
-    expect(result.completed).toBe(1);
-    expect(result.failed).toBe(0);
-    expect(vi.mocked(log.warn)).toHaveBeenCalledWith(
-      expect.stringContaining("close completed spec issues"),
-    );
   });
 
   it("logs warning and continues when datasource.update() fails in post-execution sync", async () => {


### PR DESCRIPTION
## Summary

Removes the `closeCompletedSpecIssues` function and all its usages so that issues are closed naturally by PR merge via the auto-close references already present in PR bodies, rather than being closed directly by the dispatch pipeline.

Closes #227

## Changes

- **`src/orchestrator/datasource-helpers.ts`**: Removed the `closeCompletedSpecIssues` function definition and its now-unused imports (`getDatasource`, `detectDatasource`, `TaskFile`).
- **`src/orchestrator/dispatch-pipeline.ts`**: Removed the `closeCompletedSpecIssues` invocation (step 6 try/catch block) and its import. Renumbered the cleanup step from 7 → 6.
- **`src/tests/datasource-helpers.test.ts`**: Removed the entire `closeCompletedSpecIssues` test suite, its helper functions, and the associated `getDatasource`/`detectDatasource` mocks that were only used by those tests.
- **`src/tests/dispatch-pipeline.test.ts`**: Removed the `closeCompletedSpecIssues` mock, its import, and the error-path test case that exercised its rejection handling.

## Motivation

Previously, the dispatch pipeline would close issues directly after all tasks in a spec file completed successfully. This was redundant because PR bodies already contain auto-close references (e.g., `Closes #42`), so merging the PR naturally closes the issue. The direct close caused issues to be closed prematurely — before the PR was reviewed and merged.