### PR TITLE
Fix TUI dashboard flickering on Windows terminals

### DIFF
--- a/src/tui.ts
+++ b/src/tui.ts
@@ -298,16 +298,35 @@ function render(state: TuiState): string {
 
 /**
  * Clear the previous render and draw a new frame.
+ * Uses a single-write, per-line overwrite strategy to eliminate flicker.
  */
 function draw(state: TuiState): void {
-  // Move cursor up and clear previous output
-  if (lastLineCount > 0) {
-    process.stdout.write(`\x1B[${lastLineCount}A\x1B[0J`);
-  }
   const output = render(state);
-  process.stdout.write(output);
   const cols = process.stdout.columns || 80;
-  lastLineCount = countVisualRows(output, cols);
+  const newLineCount = countVisualRows(output, cols);
+
+  let buffer = "";
+
+  // Move cursor up to the beginning of the previous frame
+  if (lastLineCount > 0) {
+    buffer += `\x1B[${lastLineCount}A`;
+  }
+
+  // Append each line with \x1B[K (Erase to End of Line)
+  const lines = output.split("\n");
+  buffer += lines.map((line) => line + "\x1B[K").join("\n");
+
+  // Clean up leftover rows if new frame is shorter than previous
+  const leftover = lastLineCount - newLineCount;
+  if (leftover > 0) {
+    for (let i = 0; i < leftover; i++) {
+      buffer += "\n\x1B[K";
+    }
+    buffer += `\x1B[${leftover}A`;
+  }
+
+  process.stdout.write(buffer);
+  lastLineCount = newLineCount;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #200 — eliminates rapid visual flickering of the TUI dashboard by replacing the two-step clear-then-redraw rendering strategy with a single-write, per-line overwrite approach.

## What changed

The `draw()` function in `src/tui.ts` was refactored to build the entire frame as a single string buffer before writing to stdout:

- **Cursor repositioning**: moves the cursor up to the start of the previous frame (`\x1B[<N>A`) without clearing
- **Per-line erasure**: each line is appended with `\x1B[K` (Erase to End of Line) to overwrite stale content in-place
- **Leftover row cleanup**: if the new frame is shorter than the previous one, extra lines are erased and the cursor is repositioned
- **Single write**: the entire buffer is emitted in one `process.stdout.write()` call, eliminating the visible gap between clearing and redrawing

The previous approach used a separate write to move the cursor up and erase below (`\x1B[0J`), followed by a second write for the new frame. This two-write strategy caused a brief blank flash visible as flickering, especially on Windows terminals.