### PR TITLE
Fix task checkbox sync for md datasource source files

### DIFF
--- a/src/orchestrator/dispatch-pipeline.ts
+++ b/src/orchestrator/dispatch-pipeline.ts
@@ -494,12 +494,18 @@ export async function runDispatchPipeline(
                 // Sync checked-off state back to the datasource
                 try {
                   const parsed = parseIssueFilename(task.file);
+                  const updatedContent = await readFile(task.file, "utf-8");
                   if (parsed) {
-                    const updatedContent = await readFile(task.file, "utf-8");
                     const issueDetails = issueDetailsByFile.get(task.file);
                     const title = issueDetails?.title ?? parsed.slug;
                     await datasource.update(parsed.issueId, title, updatedContent, fetchOpts);
                     log.success(`Synced task completion to issue #${parsed.issueId}`);
+                  } else {
+                    const issueDetails = issueDetailsByFile.get(task.file);
+                    if (issueDetails) {
+                      await datasource.update(issueDetails.number, issueDetails.title, updatedContent, fetchOpts);
+                      log.success(`Synced task completion to issue #${issueDetails.number}`);
+                    }
                   }
                 } catch (err) {
                   log.warn(`Could not sync task completion to datasource: ${log.formatErrorChain(err)}`);
@@ -836,7 +842,7 @@ export async function dryRunMode(
     return { total: 0, completed: 0, failed: 0, skipped: 0, results: [] };
   }
 
-  const { files } = await writeItemsToTempDir(items);
+  const { files, issueDetailsByFile } = await writeItemsToTempDir(items);
 
   const taskFiles: TaskFile[] = [];
   for (const file of files) {
@@ -856,7 +862,9 @@ export async function dryRunMode(
   log.info(`Dry run — ${allTasks.length} task(s) across ${taskFiles.length} file(s):\n`);
   for (const task of allTasks) {
     const parsed = parseIssueFilename(task.file);
-    const details = parsed ? items.find((item) => item.number === parsed.issueId) : undefined;
+    const details = parsed
+      ? items.find((item) => item.number === parsed.issueId)
+      : issueDetailsByFile.get(task.file);
     const branchInfo = details
       ? ` [branch: ${datasource.buildBranchName(details.number, details.title, username)}]`
       : "";

--- a/src/tests/dispatch-pipeline.test.ts
+++ b/src/tests/dispatch-pipeline.test.ts
@@ -1652,6 +1652,38 @@ describe("error-path handling", () => {
       expect.stringContaining("Could not sync task completion"),
     );
   });
+
+  it("falls back to issueDetailsByFile when parseIssueFilename returns null (md datasource)", async () => {
+    // Simulate md-datasource where filenames are non-numeric
+    vi.mocked(parseIssueFilename).mockReturnValue(null);
+    vi.mocked(writeItemsToTempDir).mockResolvedValue({
+      files: ["/tmp/dispatch-test/1-test.md"],
+      issueDetailsByFile: new Map([["/tmp/dispatch-test/1-test.md", {
+        number: "task-complete-md.md",
+        title: "Task Complete MD",
+        body: "# Test\n\n- [ ] Implement the feature",
+        labels: [],
+        state: "open",
+        url: ".dispatch/specs/task-complete-md.md",
+        comments: [],
+        acceptanceCriteria: "",
+      }]]),
+    });
+
+    const result = await runDispatchPipeline(
+      baseOpts({ noPlan: true }),
+      "/tmp/test",
+    );
+
+    expect(result.completed).toBe(1);
+    const ds = vi.mocked(getDatasource)("md") as unknown as Datasource;
+    expect(ds.update).toHaveBeenCalledWith(
+      "task-complete-md.md",
+      "Task Complete MD",
+      expect.any(String),
+      expect.any(Object),
+    );
+  });
 });
 
 // ─── Feature branch workflow ────────────────────────────────────
@@ -2019,6 +2051,75 @@ describe("feature branch workflow", () => {
     for (const call of worktreeCalls) {
       expect(call[3]).toBe("dispatch/my-feature");
     }
+  });
+});
+
+describe("md-datasource sync fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Set up md-datasource-style issue with non-numeric filename as the number
+    const mdIssue: IssueDetails = {
+      number: "task-complete-md.md",
+      title: "Task Complete Md",
+      body: "# Task\n\n- [ ] Implement the feature",
+      labels: [],
+      state: "open",
+      url: ".dispatch/specs/task-complete-md.md",
+      comments: [],
+      acceptanceCriteria: "",
+    };
+
+    vi.mocked(fetchItemsById).mockResolvedValue([mdIssue]);
+    vi.mocked(writeItemsToTempDir).mockResolvedValue({
+      files: ["/tmp/dispatch-test/task-complete-md.md"],
+      issueDetailsByFile: new Map([
+        ["/tmp/dispatch-test/task-complete-md.md", mdIssue],
+      ]),
+    });
+    vi.mocked(parseTaskFile).mockResolvedValue({
+      path: "/tmp/dispatch-test/task-complete-md.md",
+      tasks: [{
+        index: 0,
+        text: "Implement the feature",
+        line: 3,
+        raw: "- [ ] Implement the feature",
+        file: "/tmp/dispatch-test/task-complete-md.md",
+      }],
+      content: "# Task\n\n- [ ] Implement the feature",
+    });
+    // Return null to simulate non-numeric md-datasource filename
+    vi.mocked(parseIssueFilename).mockReturnValue(null);
+    mocks.mockExecute.mockResolvedValue({
+      success: true,
+      data: { dispatchResult: { task: { index: 0, text: "Implement the feature", line: 3, raw: "- [ ] Implement the feature", file: "/tmp/dispatch-test/task-complete-md.md" }, success: true } },
+      durationMs: 100,
+    });
+    mocks.mockGenerate.mockResolvedValue({
+      commitMessage: "",
+      prTitle: "",
+      prDescription: "",
+      success: false,
+      error: "mock: not configured",
+    });
+  });
+
+  it("calls datasource.update() with filename-based issue ID when parseIssueFilename returns null", async () => {
+    const result = await runDispatchPipeline(
+      baseOpts({ noPlan: true }),
+      "/tmp/test",
+    );
+
+    expect(result.completed).toBe(1);
+    expect(result.failed).toBe(0);
+
+    const ds = vi.mocked(getDatasource)("md") as unknown as Datasource;
+    // datasource.update() should be called with the original md filename as issueId
+    expect(ds.update).toHaveBeenCalledWith(
+      "task-complete-md.md",
+      "Task Complete Md",
+      expect.any(String),
+      expect.any(Object),
+    );
   });
 });
 


### PR DESCRIPTION
Closes #262

## Problem

When using the `md` datasource, task checkboxes (`[ ]`) were never updated to `[x]`) after successful execution. The sync logic in `dispatch-pipeline.ts` relied on `parseIssueFilename()` to extract a numeric issue ID from the temp filename, but md-datasource files use non-numeric filenames (e.g., `task-complete-md.md`), causing `parseIssueFilename()` to return `null` and silently skip the update.

## Changes

**`src/orchestrator/dispatch-pipeline.ts`**
- Added an `else` branch in the task-completion sync block that falls back to `issueDetailsByFile` when `parseIssueFilename` returns `null`, calling `datasource.update()` with the original issue's `number` and `title` from the map
- Moved `readFile` call before the `if/else` so the updated content is available in both branches
- Fixed `dryRunMode` to destructure `issueDetailsByFile` from `writeItemsToTempDir` and use it as a fallback for resolving issue details when `parseIssueFilename` returns `null`

**`src/tests/dispatch-pipeline.test.ts`**
- Added inline test in the existing error-path suite verifying `datasource.update()` is called with filename-based issue ID when `parseIssueFilename` returns `null`
- Added a dedicated `md-datasource sync fallback` describe block with full setup for the md-datasource scenario, asserting correct arguments to `datasource.update()`