### PR TITLE
Update Node.js version in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - package.json
+  workflow_dispatch:
 
 concurrency:
   group: publish-${{ github.ref }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing by adding a manual trigger and upgrading the Node.js version used. These changes improve the flexibility and future-proofing of the workflow.

Workflow improvements:

* Added a `workflow_dispatch` trigger to `.github/workflows/publish.yml`, allowing the workflow to be manually started from the GitHub UI.

Dependency updates:

* Updated the Node.js version in the setup step from 22 to 24 to ensure compatibility with newer features and packages.