### PR TITLE
Fix Azure DevOps dispatch failure by removing unsupported --project flag from work-item show/update calls

### DIFF
--- a/src/datasources/azdevops.ts
+++ b/src/datasources/azdevops.ts
@@ -197,7 +197,6 @@ export const datasource: Datasource = {
         "--output", "json",
       ];
       if (opts.org) batchArgs.push("--org", opts.org);
-      if (opts.project) batchArgs.push("--project", opts.project);
 
       const { stdout: batchStdout } = await exec("az", batchArgs, {
         cwd: opts.cwd || process.cwd(),
@@ -254,9 +253,6 @@ export const datasource: Datasource = {
     if (opts.org) {
       args.push("--org", opts.org);
     }
-    if (opts.project) {
-      args.push("--project", opts.project);
-    }
 
     const { stdout } = await exec("az", args, {
       cwd: opts.cwd || process.cwd(),
@@ -292,7 +288,6 @@ export const datasource: Datasource = {
       body,
     ];
     if (opts.org) args.push("--org", opts.org);
-    if (opts.project) args.push("--project", opts.project);
     await exec("az", args, { cwd: opts.cwd || process.cwd(), shell: process.platform === "win32" });
   },
 
@@ -312,7 +307,6 @@ export const datasource: Datasource = {
         "json",
       ];
       if (opts.org) showArgs.push("--org", opts.org);
-      if (opts.project) showArgs.push("--project", opts.project);
       const { stdout } = await exec("az", showArgs, {
         cwd: opts.cwd || process.cwd(),
         shell: process.platform === "win32",
@@ -339,7 +333,6 @@ export const datasource: Datasource = {
       state,
     ];
     if (opts.org) args.push("--org", opts.org);
-    if (opts.project) args.push("--project", opts.project);
     await exec("az", args, { cwd: opts.cwd || process.cwd(), shell: process.platform === "win32" });
   },
 
@@ -577,9 +570,6 @@ async function fetchComments(
 
     if (opts.org) {
       args.push("--org", opts.org);
-    }
-    if (opts.project) {
-      args.push("--project", opts.project);
     }
 
     const { stdout } = await exec("az", args, {

--- a/src/tests/azdevops-datasource.test.ts
+++ b/src/tests/azdevops-datasource.test.ts
@@ -129,12 +129,11 @@ describe("azdevops datasource — list", () => {
 
     await datasource.list({ cwd: "/tmp", org: "https://dev.azure.com/myorg", project: "MyProj" });
 
-    // Verify batch call (second call) includes --org and --project
+    // Verify batch call (second call) includes --org but NOT --project (show doesn't accept it)
     const batchArgs = mockExecFile.mock.calls[1][1] as string[];
     expect(batchArgs).toContain("--org");
     expect(batchArgs).toContain("https://dev.azure.com/myorg");
-    expect(batchArgs).toContain("--project");
-    expect(batchArgs).toContain("MyProj");
+    expect(batchArgs).not.toContain("--project");
   });
 
   it("appends iteration filter to WIQL query", async () => {
@@ -241,6 +240,7 @@ describe("azdevops datasource — fetch", () => {
     const fetchArgs = mockExecFile.mock.calls[0][1] as string[];
     expect(fetchArgs).toContain("--org");
     expect(fetchArgs).toContain("org-url");
+    expect(fetchArgs).not.toContain("--project");
   });
 
   it("returns empty comments when fetchComments fails", async () => {
@@ -391,7 +391,7 @@ describe("azdevops datasource — update", () => {
 
     const args = mockExecFile.mock.calls[0][1] as string[];
     expect(args).toContain("--org");
-    expect(args).toContain("--project");
+    expect(args).not.toContain("--project");
   });
 });
 
@@ -534,12 +534,14 @@ describe("azdevops datasource — close", () => {
     const showArgs = mockExecFile.mock.calls[0][1] as string[];
     expect(showArgs).toContain("--org");
     expect(showArgs).toContain("close-org5");
-    expect(showArgs).toContain("--project");
-    expect(showArgs).toContain("close-proj5");
+    expect(showArgs).not.toContain("--project");
+
+    const stateListArgs = mockExecFile.mock.calls[1][1] as string[];
+    expect(stateListArgs).toContain("--project");
 
     const updateArgs = mockExecFile.mock.calls[2][1] as string[];
     expect(updateArgs).toContain("--org");
-    expect(updateArgs).toContain("--project");
+    expect(updateArgs).not.toContain("--project");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #274 — Creating an issue in Azure DevOps worked, but dispatching it failed because the `--project` flag was being passed to `az boards work-item show` and `az boards work-item update`, which do not accept that argument.

## Changes

### `src/datasources/azdevops.ts`
- Removed `--project` from `az boards work-item show` invocations in `fetch()`, `list()` (batch call), and `close()`
- Removed `--project` from `az boards work-item update` invocations in `update()` and `close()`
- Removed `--project` from `fetchComments()` since `work-item relation list-comment` does not support it either
- Left `--project` intact for commands that require it: `az boards query`, `az boards work-item create`, `az boards work-item type list`, and `az boards work-item type state list`

### `src/tests/azdevops-datasource.test.ts`
- Updated assertions in `list`, `fetch`, `update`, and `close` test suites to verify `--project` is **not** included in `work-item show` and `work-item update` argument arrays
- Added explicit `expect(args).not.toContain("--project")` checks to prevent regression
- Verified that `--project` assertions remain for commands that still require it (e.g., `type state list`)