### PR TITLE
Switch version bump workflow to daily schedule and manual dispatch

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,9 +1,9 @@
 name: Version Bump
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -12,11 +12,12 @@ permissions:
 jobs:
   version:
     # Skip version-bump merges to avoid infinite loops
-    if: github.actor != 'github-actions[bot]' && !startsWith(github.event.head_commit.message, 'chore(release)')
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Closes #283

## Summary

Updates the Version Bump GitHub Action workflow to run on a daily schedule (midnight UTC) and via manual dispatch, replacing the previous `push` to `main` trigger.

## Changes

- **`.github/workflows/version.yml`**
  - Replaced `push.branches: [main]` trigger with `schedule` (daily cron `0 0 * * *`) and `workflow_dispatch`
  - Simplified the job-level `if` condition by removing the `head_commit.message` check (no longer applicable since the workflow is no longer triggered by pushes)
  - Added explicit `ref: main` to the checkout step to ensure the correct branch is checked out for scheduled and manual runs

- **`package.json` / `package-lock.json`**
  - Reverted version from `1.4.1` to `1.4.0` (aligning with the version prior to the workflow change)

## Why

The previous push-based trigger only ran version bumps when commits were pushed to `main`, which limited bump frequency. A daily schedule and manual dispatch allow more flexible and frequent version bumps without requiring a push event.