### PR TITLE
Update spec test for in-place writing behavior in MD datasource

### DIFF
--- a/src/orchestrator/spec-pipeline.ts
+++ b/src/orchestrator/spec-pipeline.ts
@@ -398,16 +398,8 @@ async function generateSpecsBatch(
                   log.success(`Updated spec #${parsed.issueId} in-place`);
                   identifier = parsed.issueId;
                   issueNumbers.push(parsed.issueId);
-                } else {
-                  const created = await datasource.create(details.title, result.data.content, fetchOpts);
-                  log.success(`Created spec #${created.number}: ${created.url}`);
-                  if (filepath !== created.url) {
-                    await unlink(filepath);
-                  }
-                  filepath = created.url;
-                  identifier = created.number;
-                  issueNumbers.push(created.number);
                 }
+                // If no ID prefix, spec is already written in-place at filepath — no sync needed
               } else {
                 const created = await datasource.create(details.title, result.data.content, fetchOpts);
                 log.success(`Created issue #${created.number} from ${filepath}`);

--- a/src/tests/spec-pipeline.test.ts
+++ b/src/tests/spec-pipeline.test.ts
@@ -374,7 +374,7 @@ describe("runSpecPipeline", () => {
       expect(result.issueNumbers).toContain("99");
     });
 
-    it("creates spec with auto-assigned ID when datasource is md and file has no ID prefix", async () => {
+    it("writes spec in-place when datasource is md and file has no ID prefix", async () => {
       vi.mocked(getDatasource).mockReturnValue(
         createMockDatasource("md", {
           fetch: mocks.mockFetch,
@@ -382,28 +382,14 @@ describe("runSpecPipeline", () => {
           create: mocks.mockCreate,
         }),
       );
-      mocks.mockCreate.mockResolvedValue({
-        number: "1",
-        title: "Mock Title",
-        body: "# Generated Spec\n\n## Tasks\n\n- [ ] Do something",
-        labels: [],
-        state: "open",
-        url: "/tmp/test-cwd/.dispatch/specs/1-mock-title.md",
-        comments: [],
-        acceptanceCriteria: "",
-      });
       mocks.mockGlob.mockResolvedValue(["/tmp/test-cwd/spec1.md"]);
       vi.mocked(readFile).mockResolvedValue("# File Content\n\nBody");
 
       const result = await runSpecPipeline(baseOpts({ issues: "*.md" }));
 
-      expect(mocks.mockCreate).toHaveBeenCalledWith(
-        "Mock Title",
-        expect.any(String),
-        expect.any(Object),
-      );
-      expect(unlink).toHaveBeenCalledWith("/tmp/test-cwd/spec1.md");
-      expect(result.issueNumbers).toContain("1");
+      expect(mocks.mockCreate).not.toHaveBeenCalled();
+      expect(unlink).not.toHaveBeenCalled();
+      expect(result.issueNumbers).toHaveLength(0);
       expect(result.generated).toBe(1);
     });
 


### PR DESCRIPTION
This pull request updates the spec pipeline logic to avoid creating new specs or deleting files when processing Markdown files that do not have an ID prefix. Instead, such specs are now written in-place, and no synchronization with the datasource is performed. The related test has been updated to reflect this new behavior.

**Spec pipeline logic changes:**

* Updated `generateSpecsBatch` in `spec-pipeline.ts` to skip creating new specs and deleting files when the datasource is Markdown and the file has no ID prefix, treating these as already written in-place.

**Test updates:**

* Modified the corresponding test in `spec-pipeline.test.ts` to verify that `create` and `unlink` are not called in this case, and that no new issue numbers are returned.