### PR TITLE
feat: add dispatch-orchestration skill for skills.sh

### DIFF
--- a/.claude/skills/dispatch-orchestration
+++ b/.claude/skills/dispatch-orchestration
@@ -1,0 +1,1 @@
+../../skills/dispatch-orchestration

--- a/.claude/skills/find-skills/SKILL.md
+++ b/.claude/skills/find-skills/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: find-skills
+description: Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
+---
+
+# Find Skills
+
+This skill helps you discover and install skills from the open agent skills ecosystem.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks "how do I do X" where X might be a common task with an existing skill
+- Says "find a skill for X" or "is there a skill for X"
+- Asks "can you do X" where X is a specialized capability
+- Expresses interest in extending agent capabilities
+- Wants to search for tools, templates, or workflows
+- Mentions they wish they had help with a specific domain (design, testing, deployment, etc.)
+
+## What is the Skills CLI?
+
+The Skills CLI (`npx skills`) is the package manager for the open agent skills ecosystem. Skills are modular packages that extend agent capabilities with specialized knowledge, workflows, and tools.
+
+**Key commands:**
+
+- `npx skills find [query]` - Search for skills interactively or by keyword
+- `npx skills add <package>` - Install a skill from GitHub or other sources
+- `npx skills check` - Check for skill updates
+- `npx skills update` - Update all installed skills
+
+**Browse skills at:** https://skills.sh/
+
+## How to Help Users Find Skills
+
+### Step 1: Understand What They Need
+
+When a user asks for help with something, identify:
+
+1. The domain (e.g., React, testing, design, deployment)
+2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
+3. Whether this is a common enough task that a skill likely exists
+
+### Step 2: Check the Leaderboard First
+
+Before running a CLI search, check the [skills.sh leaderboard](https://skills.sh/) to see if a well-known skill already exists for the domain. The leaderboard ranks skills by total installs, surfacing the most popular and battle-tested options.
+
+For example, top skills for web development include:
+- `vercel-labs/agent-skills` — React, Next.js, web design (100K+ installs each)
+- `anthropics/skills` — Frontend design, document processing (100K+ installs)
+
+### Step 3: Search for Skills
+
+If the leaderboard doesn't cover the user's need, run the find command:
+
+```bash
+npx skills find [query]
+```
+
+For example:
+
+- User asks "how do I make my React app faster?" → `npx skills find react performance`
+- User asks "can you help me with PR reviews?" → `npx skills find pr review`
+- User asks "I need to create a changelog" → `npx skills find changelog`
+
+### Step 4: Verify Quality Before Recommending
+
+**Do not recommend a skill based solely on search results.** Always verify:
+
+1. **Install count** — Prefer skills with 1K+ installs. Be cautious with anything under 100.
+2. **Source reputation** — Official sources (`vercel-labs`, `anthropics`, `microsoft`) are more trustworthy than unknown authors.
+3. **GitHub stars** — Check the source repository. A skill from a repo with <100 stars should be treated with skepticism.
+
+### Step 5: Present Options to the User
+
+When you find relevant skills, present them to the user with:
+
+1. The skill name and what it does
+2. The install count and source
+3. The install command they can run
+4. A link to learn more at skills.sh
+
+Example response:
+
+```
+I found a skill that might help! The "react-best-practices" skill provides
+React and Next.js performance optimization guidelines from Vercel Engineering.
+(185K installs)
+
+To install it:
+npx skills add vercel-labs/agent-skills@react-best-practices
+
+Learn more: https://skills.sh/vercel-labs/agent-skills/react-best-practices
+```
+
+### Step 6: Offer to Install
+
+If the user wants to proceed, you can install the skill for them:
+
+```bash
+npx skills add <owner/repo@skill> -g -y
+```
+
+The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts.
+
+## Common Skill Categories
+
+When searching, consider these common categories:
+
+| Category        | Example Queries                          |
+| --------------- | ---------------------------------------- |
+| Web Development | react, nextjs, typescript, css, tailwind |
+| Testing         | testing, jest, playwright, e2e           |
+| DevOps          | deploy, docker, kubernetes, ci-cd        |
+| Documentation   | docs, readme, changelog, api-docs        |
+| Code Quality    | review, lint, refactor, best-practices   |
+| Design          | ui, ux, design-system, accessibility     |
+| Productivity    | workflow, automation, git                |
+
+## Tips for Effective Searches
+
+1. **Use specific keywords**: "react testing" is better than just "testing"
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
+
+## When No Skills Are Found
+
+If no relevant skills exist:
+
+1. Acknowledge that no existing skill was found
+2. Offer to help with the task directly using your general capabilities
+3. Suggest the user could create their own skill with `npx skills init`
+
+Example:
+
+```
+I searched for skills related to "xyz" but didn't find any matches.
+I can still help you with this task directly! Would you like me to proceed?
+
+If this is something you do often, you could create your own skill:
+npx skills init my-xyz-skill
+```

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "skills": {
+    "find-skills": {
+      "source": "vercel-labs/skills",
+      "sourceType": "github",
+      "computedHash": "9e1c8b3103f92fa8092568a44fe64858de7c5c9dc65ce4bea8f168080e889cfd"
+    }
+  }
+}

--- a/skills/dispatch-orchestration/SKILL.md
+++ b/skills/dispatch-orchestration/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: dispatch-orchestration
+description: >
+  Orchestrate work using the Dispatch CLI (@pruddiman/dispatch). Use when the
+  user wants to spec issues, dispatch tasks, plan execution order, manage
+  dependencies between issues, or run any dispatch command. Covers correct
+  spec ordering, dependency analysis, and the spec-plan-execute pipeline.
+metadata:
+  author: pruddiman
+  version: "1.0.0"
+license: MIT
+---
+
+# Dispatch Orchestration
+
+Dispatch is an AI agent orchestration CLI that turns issues into working code. It fetches work items from GitHub Issues, Azure DevOps, or local markdown files, generates structured specs (with correctly ordered and tagged tasks), plans and executes each task in isolated AI sessions, then commits and opens PRs.
+
+**Pipeline:** Issues → `--spec` → Spec files → `dispatch` → Plan → Execute → Commit/PR
+
+## CLI Quick Reference
+
+| Command | What it does |
+|---|---|
+| `dispatch --spec 42,43` | Generate specs from issue IDs |
+| `dispatch --spec "add dark mode"` | Generate spec from inline text |
+| `dispatch --respec 42` | Regenerate an existing spec |
+| `dispatch 42` | Execute issue (plan + execute) |
+| `dispatch ".dispatch/specs/*.md"` | Execute specs by glob |
+| `dispatch --dry-run 42` | Preview tasks without executing |
+| `dispatch --no-plan 42` | Skip planner, execute directly |
+| `dispatch --provider claude` | Use Claude Code as provider |
+| `dispatch --concurrency 4` | Max parallel tasks |
+| `dispatch --fix-tests 42` | Run tests and fix failures |
+| `dispatch --feature my-feat 42,43` | Group issues into one feature branch |
+| `dispatch config` | Interactive configuration wizard |
+
+**Key flags:** `--plan-timeout <min>`, `--retries <n>`, `--spec-timeout <min>`, `--no-branch`, `--no-worktree`, `--verbose`
+
+## Pipeline Phases
+
+### When to Spec (`--spec`)
+
+Use `--spec` when:
+- The issue is vague or complex and needs codebase exploration
+- You need structured task lists with ordering tags
+- Multiple people/agents will execute the work
+
+Skip `--spec` when:
+- You already have a well-structured markdown task file
+- The task is a single, obvious change
+
+### When to Plan (default) vs Skip (`--no-plan`)
+
+The planner reads each task, explores the codebase, and produces a line-level execution plan.
+
+- **Use planning (default):** Complex tasks, unfamiliar code, refactors
+- **Skip planning (`--no-plan`):** Simple/mechanical tasks, typo fixes, config changes
+
+### When to Dry-Run (`--dry-run`)
+
+Always dry-run before dispatching unfamiliar specs to verify task count, ordering, and grouping.
+
+## Spec Ordering — The Core Discipline
+
+**This is the most critical part of using Dispatch correctly.** The agent's primary job is deciding *which* issues to spec and *when* — not writing the P/S/I tags inside specs (Dispatch's `--spec` agent handles task-level tagging automatically).
+
+### The Rule
+
+**Never spec an issue whose prerequisites are not fully implemented.**
+
+The spec agent explores the current codebase when generating a spec. If issue B depends on code that issue A creates, and A hasn't been executed yet, then B's spec will be wrong — it will be written against a codebase that's missing the foundations B needs.
+
+### Dependency Analysis Workflow
+
+Before speccing anything, analyze all issues and build a dependency graph:
+
+1. **Read all issue descriptions.** Identify what each issue creates, modifies, or depends on.
+2. **Map dependencies.** If issue B says "add API endpoints for user model" and issue A says "add user model", then B depends on A.
+3. **Identify independent issues.** Issues with no shared dependencies can be specced and executed in parallel.
+4. **Number or order specs by dependency layer.** Layer 0 has no deps. Layer 1 depends on layer 0. Layer 2 depends on layer 1. Etc.
+
+### Execution Pattern
+
+```
+Layer 0 (no deps):      spec → execute → verify
+                              ↓
+Layer 1 (depends on 0):  spec → execute → verify
+                              ↓
+Layer 2 (depends on 1):  spec → execute → verify
+```
+
+**Within each layer**, independent issues can be specced and executed concurrently.
+**Between layers**, you must wait for the prior layer to complete before speccing the next.
+
+### Concrete Example
+
+**Issues:**
+- #10 "Add user model" — no dependencies
+- #11 "Add user API endpoints" — depends on #10 (imports user model)
+- #12 "Add admin dashboard" — depends on #11 (calls user API)
+- #20 "Add logging middleware" — no dependencies (independent of #10-#12)
+- #21 "Add request tracing" — depends on #20 (extends logging middleware)
+
+**Dependency graph:**
+```
+Layer 0: #10, #20          (independent — parallel)
+Layer 1: #11, #21          (#11 depends on #10; #21 depends on #20 — parallel within layer)
+Layer 2: #12               (depends on #11)
+```
+
+**Correct workflow:**
+```bash
+# Layer 0 — spec and execute all independent issues
+dispatch --spec 10,20              # Safe: no prerequisites
+dispatch 10,20 --concurrency 2    # Execute in parallel
+
+# Layer 1 — now safe to spec issues that depend on layer 0
+dispatch --spec 11,21              # Safe: #10 and #20 code exists
+dispatch 11,21 --concurrency 2    # Execute in parallel
+
+# Layer 2 — depends on layer 1
+dispatch --spec 12                 # Safe: #11 code exists
+dispatch 12                        # Execute
+```
+
+**Incorrect workflows:**
+```bash
+# BAD: speccing everything at once
+dispatch --spec 10,11,12,20,21    # #11's spec can't reference #10's code (doesn't exist yet)
+
+# BAD: executing out of order
+dispatch 10,11,12                 # #11 may fail — #10's code doesn't exist when #11 starts
+
+# BAD: speccing layer 1 before layer 0 is executed
+dispatch --spec 10,20
+dispatch --spec 11,21              # WRONG: #10 and #20 haven't been EXECUTED yet
+```
+
+### Decision Checklist (Before Speccing an Issue)
+
+Ask these questions for each issue before running `dispatch --spec`:
+
+1. **What code does this issue depend on?** (imports, APIs, schemas, utilities)
+2. **Does that code exist in the codebase right now?** Check with grep/find.
+3. **If not, which issue creates it?** That issue must be fully executed first.
+4. **Are there other issues at the same dependency layer?** Spec them together for parallelism.
+
+If all dependencies exist in the codebase → safe to spec.
+If any dependency is missing → wait. Spec and execute the prerequisite first.
+
+## How Task Ordering Works Inside Specs
+
+> **You don't need to write P/S/I tags yourself.** `dispatch --spec` generates specs with correctly tagged and ordered tasks automatically. This section is background so you understand how Dispatch executes the specs it generates.
+
+Each task in a spec has an execution-mode prefix:
+
+- `(P)` **Parallel-safe** — runs concurrently with other `(P)` tasks
+- `(S)` **Serial / dependent** — waits for all prior tasks, then runs alone
+- `(I)` **Isolated / barrier** — runs completely alone (for validation: tests, lint, build)
+
+Dispatch groups consecutive `(P)` tasks together and runs them concurrently. An `(S)` task caps the current group. An `(I)` task flushes everything and runs alone. Groups execute sequentially.
+
+**Example of a generated spec's tasks:**
+```markdown
+- [ ] (P) Add validation helper to utils
+- [ ] (P) Add unit tests for validation helper
+- [ ] (S) Refactor form component to use helper      ← waits for above
+- [ ] (P) Update form documentation
+- [ ] (I) Run the full test suite                     ← runs alone, last
+```
+
+See [references/ordering-reference.md](references/ordering-reference.md) for the full grouping algorithm and edge cases.
+
+## Workflow Recipes
+
+### Single issue, full pipeline
+```bash
+dispatch --spec 42                    # Generate spec
+cat .dispatch/specs/42-*.md           # Review the spec
+dispatch --dry-run 42                 # Preview tasks
+dispatch 42                           # Plan + execute
+```
+
+### Multiple independent issues
+```bash
+dispatch --spec 42,43,44              # Spec concurrently (independent)
+dispatch 42,43,44 --concurrency 3     # Execute concurrently
+```
+
+### Dependent issue chain
+```bash
+dispatch --spec 42 && dispatch 42     # Layer 0: foundation
+dispatch --spec 43 && dispatch 43     # Layer 1: depends on 42
+dispatch --spec 44 && dispatch 44     # Layer 2: depends on 43
+```
+
+### Mixed dependencies and independent issues
+```bash
+# Layer 0
+dispatch --spec 10,20 && dispatch 10,20 --concurrency 2
+# Layer 1
+dispatch --spec 11,21 && dispatch 11,21 --concurrency 2
+# Layer 2
+dispatch --spec 12 && dispatch 12
+```
+
+### From inline description
+```bash
+dispatch --spec "add dark mode toggle to settings page"
+dispatch ".dispatch/specs/*.md"
+```
+
+### Quick fix, skip planning
+```bash
+dispatch --no-plan 42
+```
+
+### Fix failing tests
+```bash
+dispatch --fix-tests 42
+```
+
+### Feature branch grouping
+```bash
+dispatch --feature user-system 10,11,12    # All on one branch
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Spec references code that doesn't exist | Prerequisite issue hasn't been executed yet | Execute the prerequisite first, then `--respec` |
+| Task fails — "file not found" or "symbol not found" | Task depends on code from a prior issue that isn't done | Execute issues in dependency order; re-spec if needed |
+| Spec quality is poor / tasks seem wrong | Spec was generated before prerequisite code existed | Execute prerequisites, then `dispatch --respec` |
+| Planner times out | Complex task + default 30-min limit | `--plan-timeout 60` or `--no-plan` for simpler tasks |
+| Too slow — everything sequential | Issues dispatched one at a time despite being independent | Identify independent issues and spec/execute them concurrently |
+| Task runs but doesn't commit | Commit instructions missing from task | Re-spec with `--respec` (spec agent embeds commit instructions) |

--- a/skills/dispatch-orchestration/references/ordering-reference.md
+++ b/skills/dispatch-orchestration/references/ordering-reference.md
@@ -1,0 +1,215 @@
+# P/S/I Ordering Reference
+
+Detailed reference for Dispatch's task grouping algorithm and execution ordering.
+
+## The `groupTasksByMode()` Algorithm
+
+The algorithm in `src/parser.ts` converts a flat list of tagged tasks into ordered execution groups:
+
+```
+Input:  flat list of tasks, each with mode: "parallel" | "serial" | "isolated"
+Output: array of groups (Task[][]), executed sequentially
+```
+
+**Rules:**
+
+1. **Parallel `(P)`** — accumulate into the current group
+2. **Serial `(S)`** — append to the current group, then start a new empty group (acts as a "cap")
+3. **Isolated `(I)`** — flush any accumulated tasks as their own group, then create a solo group for the isolated task
+
+After processing all tasks, any remaining accumulated parallel tasks form a final group.
+
+## Walkthrough Examples
+
+### Example 1: Mixed modes
+
+```markdown
+- [ ] (P) Task A
+- [ ] (P) Task B
+- [ ] (S) Task C
+- [ ] (P) Task D
+- [ ] (P) Task E
+- [ ] (I) Task F
+- [ ] (P) Task G
+```
+
+**Step-by-step:**
+
+| Task | Mode | Action | Current group | Groups so far |
+|------|------|--------|--------------|---------------|
+| A | P | accumulate | [A] | [] |
+| B | P | accumulate | [A, B] | [] |
+| C | S | cap group | [] | [[A, B, C]] |
+| D | P | accumulate | [D] | [[A, B, C]] |
+| E | P | accumulate | [D, E] | [[A, B, C]] |
+| F | I | flush + solo | [] | [[A, B, C], [D, E], [F]] |
+| G | P | accumulate | [G] | [[A, B, C], [D, E], [F]] |
+| end | — | flush remaining | [] | [[A, B, C], [D, E], [F], [G]] |
+
+**Result:** `[[A, B, C], [D, E], [F], [G]]`
+
+**Execution:**
+1. A, B run concurrently → C runs (S caps the group, so C waits for A and B)
+2. D, E run concurrently
+3. F runs alone (isolated)
+4. G runs alone (only task in its group)
+
+### Example 2: All parallel
+
+```markdown
+- [ ] (P) Task A
+- [ ] (P) Task B
+- [ ] (P) Task C
+```
+
+**Result:** `[[A, B, C]]` — all three run concurrently in one group.
+
+### Example 3: All serial
+
+```markdown
+- [ ] (S) Task A
+- [ ] (S) Task B
+- [ ] (S) Task C
+```
+
+**Result:** `[[A], [B], [C]]` — each runs alone, sequentially.
+
+### Example 4: Parallel then isolated validation
+
+```markdown
+- [ ] (P) Implement feature module
+- [ ] (P) Write unit tests for feature
+- [ ] (P) Update documentation
+- [ ] (I) Run full test suite
+- [ ] (I) Run linter
+```
+
+**Result:** `[[module, tests, docs], [test suite], [linter]]`
+
+**Execution:**
+1. Module, tests, and docs all run concurrently
+2. Full test suite runs alone
+3. Linter runs alone
+
+### Example 5: Serial dependency chain
+
+```markdown
+- [ ] (P) Create database schema migration
+- [ ] (P) Add seed data script
+- [ ] (S) Run migration and seed the database
+- [ ] (P) Implement API endpoints using new schema
+- [ ] (P) Write API integration tests
+- [ ] (I) Run all tests
+```
+
+**Result:** `[[schema, seed, run migration], [endpoints, tests], [run all tests]]`
+
+**Execution:**
+1. Schema and seed created concurrently, then migration runs (S caps)
+2. Endpoints and tests written concurrently (safe — schema exists now)
+3. Full test suite runs alone
+
+### Example 6: Isolated as a phase gate
+
+```markdown
+- [ ] (P) Refactor module A
+- [ ] (P) Refactor module B
+- [ ] (I) Run tests to verify refactors
+- [ ] (P) Update module C (imports from A and B)
+- [ ] (P) Update module D (imports from A and B)
+- [ ] (I) Run final test suite
+```
+
+**Result:** `[[A, B], [verify], [C, D], [final tests]]`
+
+The first `(I)` acts as a phase gate — it verifies the refactors before dependent work begins.
+
+## Edge Cases
+
+### Single task
+
+```markdown
+- [ ] (P) Only task
+```
+
+**Result:** `[[Only task]]` — works fine regardless of mode prefix.
+
+### Serial followed immediately by parallel
+
+```markdown
+- [ ] (S) Setup step
+- [ ] (P) Task A
+- [ ] (P) Task B
+```
+
+**Result:** `[[Setup step], [A, B]]` — serial creates its own group, then parallel tasks accumulate.
+
+### Isolated at the very start
+
+```markdown
+- [ ] (I) Clean build artifacts
+- [ ] (P) Task A
+- [ ] (P) Task B
+```
+
+**Result:** `[[Clean], [A, B]]` — isolated runs first (no prior tasks to flush), then parallel group.
+
+### No mode prefix (defaults to serial)
+
+```markdown
+- [ ] Task without prefix
+- [ ] (P) Parallel task
+```
+
+**Result:** `[[no-prefix, parallel]]` — the untagged task is treated as serial, which caps the group after it. But since the parallel task follows, it starts a new group... Actually: the untagged task (serial) starts accumulating, the `(P)` task accumulates into the same group. Then `(S)` caps — but there's no `(S)`. The untagged task is serial, so it caps immediately: `[[no-prefix], [parallel]]`.
+
+**Takeaway:** Always tag explicitly. Untagged = serial = immediate group cap.
+
+## Common Patterns
+
+### The "implement then validate" pattern
+```markdown
+- [ ] (P) Implement feature X
+- [ ] (P) Implement feature Y
+- [ ] (I) Run tests
+```
+Best for: independent features that need a shared validation gate.
+
+### The "foundation then consumers" pattern
+```markdown
+- [ ] (S) Create shared utility/interface
+- [ ] (P) Consumer A uses the utility
+- [ ] (P) Consumer B uses the utility
+- [ ] (I) Run tests
+```
+Best for: creating something that multiple subsequent tasks depend on.
+
+### The "phased rollout" pattern
+```markdown
+- [ ] (P) Phase 1 task A
+- [ ] (P) Phase 1 task B
+- [ ] (I) Verify phase 1
+- [ ] (P) Phase 2 task A (depends on phase 1)
+- [ ] (P) Phase 2 task B (depends on phase 1)
+- [ ] (I) Verify phase 2
+```
+Best for: large changes that need intermediate verification.
+
+### The "all parallel" pattern
+```markdown
+- [ ] (P) Independent change A
+- [ ] (P) Independent change B
+- [ ] (P) Independent change C
+- [ ] (I) Run tests
+```
+Best for: maximum throughput when all tasks are truly independent.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Diagnostic | Fix |
+|---|---|---|---|
+| Task reads a file that doesn't exist | Task should be `(S)` not `(P)` — it ran before the task that creates the file | Check which prior task creates the file | Move the dependent task after its prerequisite with `(S)` |
+| File has conflicts or garbled content | Two `(P)` tasks in the same group wrote to the same file | Check task descriptions for shared file targets | Make one task `(S)` after the other |
+| Tasks run slower than expected | Too many `(S)` tags killing parallelism | Count `(P)` vs `(S)` tags — most tasks should be `(P)` | Audit each `(S)` for genuine dependency |
+| Isolated task fails | Prior parallel tasks didn't complete correctly | Check logs for failures in the preceding group | Fix the failing task; `(I)` correctly waited for it |
+| Wrong execution order | Misunderstanding of how `(S)` caps groups | Use `--dry-run` to preview grouping | Reorder tasks and re-tag |


### PR DESCRIPTION
## Summary
- Adds a distributable `dispatch-orchestration` skill in skills.sh format (`skills/dispatch-orchestration/`)
- Teaches AI agents correct spec ordering: dependency analysis, layer-based speccing, and waiting for execution before speccing dependents
- Includes P/S/I grouping reference, workflow recipes, CLI quick reference, and troubleshooting guide
- Symlinked into `.claude/skills/` for local development use

## Install
```bash
npx skills add pruddiman/Dispatch@dispatch-orchestration
```

## Test plan
- [ ] `npx skills-ref validate ./skills/dispatch-orchestration` passes
- [ ] Skill activates in Claude Code when asking to "dispatch issues" or "spec issue 42"
- [ ] P/S/I grouping description matches `groupTasksByMode()` behavior in `src/parser.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)