### PR TITLE
feat: per-agent provider/model overrides and fast tier cost savings

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,9 @@ export const HELP = `
     --force                Ignore prior run state and re-run all tasks
     --concurrency <n>      Max parallel dispatches (default: min(cpus, freeMB/500), max: ${MAX_CONCURRENCY})
     --provider <name>      Agent backend: ${PROVIDER_NAMES.join(", ")} (default: opencode)
+    --model <model>        Model override (provider-specific format)
+    --fast-provider <name> Provider for fast tier (planner/commit agents, saves cost)
+    --fast-model <model>   Model for fast tier (planner/commit agents, saves cost)
     --source <name>        Issue source: ${DATASOURCE_NAMES.join(", ")} (optional; auto-detected from git remote)
     --server-url <url>     URL of a running provider server
     --plan-timeout <min>   Planning timeout in minutes (default: 30)
@@ -74,6 +77,10 @@ export const HELP = `
 
   Config:
     dispatch config                     Launch interactive configuration wizard
+    dispatch config --cwd <dir>         Configure a specific project directory
+
+    Additional settings available via config file (.dispatch/config.json):
+      workItemType, iteration, area (Azure DevOps filters), username (branch prefix)
 
   Examples:
     dispatch 14
@@ -95,6 +102,7 @@ export const HELP = `
     dispatch --spec "feature A should do x" --provider copilot
     dispatch --feature
     dispatch --feature my-feature
+    dispatch 14 15 16 --feature my-feature
     dispatch --fix-tests
     dispatch --fix-tests 14
     dispatch --fix-tests 14 15 16
@@ -133,6 +141,9 @@ export const CLI_OPTIONS_MAP: Record<string, string> = {
   feature: "feature",
   source: "issueSource",
   provider: "provider",
+  model: "model",
+  fastProvider: "fastProvider",
+  fastModel: "fastModel",
   concurrency: "concurrency",
   serverUrl: "serverUrl",
   planTimeout: "planTimeout",
@@ -174,6 +185,11 @@ export function parseArgs(argv: string[]): [ParsedArgs, Set<string>] {
     .addOption(
       new Option("--provider <name>", "Agent backend").choices(PROVIDER_NAMES),
     )
+    .option("--model <model>", "Model override (provider-specific format)")
+    .addOption(
+      new Option("--fast-provider <name>", "Fast tier provider (planner/commit)").choices(PROVIDER_NAMES),
+    )
+    .option("--fast-model <model>", "Fast tier model (planner/commit)")
     .addOption(
       new Option("--source <name>", "Issue source").choices(
         DATASOURCE_NAMES as string[],
@@ -314,6 +330,9 @@ export function parseArgs(argv: string[]): [ParsedArgs, Set<string>] {
   }
   if (opts.fixTests) args.fixTests = true;
   if (opts.feature) args.feature = opts.feature;
+  if (opts.model !== undefined) args.model = opts.model;
+  if (opts.fastProvider !== undefined) args.fastProvider = opts.fastProvider;
+  if (opts.fastModel !== undefined) args.fastModel = opts.fastModel;
   if (opts.source !== undefined) args.issueSource = opts.source;
   if (opts.concurrency !== undefined) args.concurrency = opts.concurrency;
   if (opts.serverUrl !== undefined) args.serverUrl = opts.serverUrl;

--- a/src/config-prompts.ts
+++ b/src/config-prompts.ts
@@ -98,6 +98,54 @@ export async function runInteractiveConfigWizard(configDir?: string): Promise<vo
     selectedModel = existing.model;
   }
 
+  // ── Fast tier selection (cost-saving) ──────────────────────
+  let selectedFastProvider: ProviderName | undefined = existing.fastProvider;
+  let selectedFastModel: string | undefined = existing.fastModel;
+
+  const useFastTier = await confirm({
+    message: "Use a separate fast tier for planner/commit agents? (saves cost)",
+    default: existing.fastProvider !== undefined || existing.fastModel !== undefined,
+  });
+
+  if (useFastTier) {
+    // Fast provider selection
+    const fastProvider = await select<ProviderName>({
+      message: "Select a fast tier provider:",
+      choices: PROVIDER_NAMES.map((name, i) => ({
+        name: `${installStatuses[i] ? chalk.green("●") : chalk.red("●")} ${name}`,
+        value: name,
+      })),
+      default: existing.fastProvider ?? provider,
+    });
+    selectedFastProvider = fastProvider;
+
+    // Fast model selection
+    try {
+      log.dim("Fetching available models for fast tier...");
+      const fastModels = await listProviderModels(fastProvider);
+      if (fastModels.length > 0) {
+        const fastModelChoice = await select<string>({
+          message: "Select a fast tier model:",
+          choices: [
+            { name: "default (provider decides)", value: "" },
+            ...fastModels.map((m) => ({ name: m, value: m })),
+          ],
+          default: existing.fastModel ?? "",
+        });
+        selectedFastModel = fastModelChoice || undefined;
+      } else {
+        log.dim("No models returned by fast tier provider — skipping model selection.");
+        selectedFastModel = existing.fastModel;
+      }
+    } catch {
+      log.dim("Could not list models for fast tier provider — skipping model selection.");
+      selectedFastModel = existing.fastModel;
+    }
+  } else {
+    selectedFastProvider = undefined;
+    selectedFastModel = undefined;
+  }
+
   // ── Auto-detect datasource from git remote ─────────────────
   const detectedSource = await detectDatasource(process.cwd());
   const datasourceDefault: DatasourceName | "auto" = existing.source ?? "auto";
@@ -198,6 +246,12 @@ export async function runInteractiveConfigWizard(configDir?: string): Promise<vo
 
   if (selectedModel !== undefined) {
     newConfig.model = selectedModel;
+  }
+  if (selectedFastProvider !== undefined) {
+    newConfig.fastProvider = selectedFastProvider;
+  }
+  if (selectedFastModel !== undefined) {
+    newConfig.fastModel = selectedFastModel;
   }
   if (org !== undefined) newConfig.org = org;
   if (project !== undefined) newConfig.project = project;

--- a/src/config-prompts.ts
+++ b/src/config-prompts.ts
@@ -11,8 +11,11 @@ import { log } from "./helpers/logger.js";
 import {
   loadConfig,
   saveConfig,
+  AGENT_NAMES,
   type DispatchConfig,
+  type AgentConfig,
 } from "./config.js";
+import type { AgentName } from "./agents/interface.js";
 import { PROVIDER_NAMES, listProviderModels, checkProviderInstalled } from "./providers/index.js";
 import type { ProviderName } from "./providers/interface.js";
 import {
@@ -98,52 +101,71 @@ export async function runInteractiveConfigWizard(configDir?: string): Promise<vo
     selectedModel = existing.model;
   }
 
-  // ── Fast tier selection (cost-saving) ──────────────────────
-  let selectedFastProvider: ProviderName | undefined = existing.fastProvider;
-  let selectedFastModel: string | undefined = existing.fastModel;
+  // ── Per-agent provider/model overrides ──────────────────────
+  const agentOverrides: Partial<Record<AgentName, AgentConfig>> = {};
+  const hasExistingAgents = existing.agents && Object.keys(existing.agents).length > 0;
 
-  const useFastTier = await confirm({
-    message: "Use a separate fast tier for planner/commit agents? (saves cost)",
-    default: existing.fastProvider !== undefined || existing.fastModel !== undefined,
+  const useAgentOverrides = await confirm({
+    message: "Configure per-agent provider/model overrides? (advanced, saves cost)",
+    default: hasExistingAgents ?? false,
   });
 
-  if (useFastTier) {
-    // Fast provider selection
-    const fastProvider = await select<ProviderName>({
-      message: "Select a fast tier provider:",
-      choices: PROVIDER_NAMES.map((name, i) => ({
-        name: `${installStatuses[i] ? chalk.green("●") : chalk.red("●")} ${name}`,
-        value: name,
-      })),
-      default: existing.fastProvider ?? provider,
-    });
-    selectedFastProvider = fastProvider;
+  if (useAgentOverrides) {
+    console.log();
+    log.dim(`Each agent inherits from the top-level provider (${provider}) unless overridden.`);
+    console.log();
 
-    // Fast model selection
-    try {
-      log.dim("Fetching available models for fast tier...");
-      const fastModels = await listProviderModels(fastProvider);
-      if (fastModels.length > 0) {
-        const fastModelChoice = await select<string>({
-          message: "Select a fast tier model:",
-          choices: [
-            { name: "default (provider decides)", value: "" },
-            ...fastModels.map((m) => ({ name: m, value: m })),
-          ],
-          default: existing.fastModel ?? "",
-        });
-        selectedFastModel = fastModelChoice || undefined;
-      } else {
-        log.dim("No models returned by fast tier provider — skipping model selection.");
-        selectedFastModel = existing.fastModel;
+    for (const role of AGENT_NAMES) {
+      const existingAgent = existing.agents?.[role];
+      const wantOverride = await confirm({
+        message: `Override ${role} agent?`,
+        default: existingAgent !== undefined,
+      });
+
+      if (!wantOverride) continue;
+
+      // Provider selection for this agent
+      const agentProvider = await select<ProviderName | "">({
+        message: `  ${role} — provider:`,
+        choices: [
+          { name: `inherit (${provider})`, value: "" },
+          ...PROVIDER_NAMES.map((name, i) => ({
+            name: `${installStatuses[i] ? chalk.green("●") : chalk.red("●")} ${name}`,
+            value: name,
+          })),
+        ],
+        default: existingAgent?.provider ?? "",
+      });
+
+      // Model selection for this agent
+      const effectiveProvider = (agentProvider || provider) as ProviderName;
+      let agentModel: string | undefined;
+      try {
+        const agentModels = await listProviderModels(effectiveProvider);
+        if (agentModels.length > 0) {
+          const modelChoice = await select<string>({
+            message: `  ${role} — model:`,
+            choices: [
+              { name: "inherit (top-level model)", value: "" },
+              ...agentModels.map((m) => ({ name: m, value: m })),
+            ],
+            default: existingAgent?.model ?? "",
+          });
+          agentModel = modelChoice || undefined;
+        }
+      } catch {
+        log.dim(`  Could not list models for ${effectiveProvider} — skipping model selection.`);
+        agentModel = existingAgent?.model;
       }
-    } catch {
-      log.dim("Could not list models for fast tier provider — skipping model selection.");
-      selectedFastModel = existing.fastModel;
+
+      // Only store if something differs from top-level
+      if (agentProvider || agentModel) {
+        const cfg: AgentConfig = {};
+        if (agentProvider) cfg.provider = agentProvider as ProviderName;
+        if (agentModel) cfg.model = agentModel;
+        agentOverrides[role] = cfg;
+      }
     }
-  } else {
-    selectedFastProvider = undefined;
-    selectedFastModel = undefined;
   }
 
   // ── Auto-detect datasource from git remote ─────────────────
@@ -247,11 +269,8 @@ export async function runInteractiveConfigWizard(configDir?: string): Promise<vo
   if (selectedModel !== undefined) {
     newConfig.model = selectedModel;
   }
-  if (selectedFastProvider !== undefined) {
-    newConfig.fastProvider = selectedFastProvider;
-  }
-  if (selectedFastModel !== undefined) {
-    newConfig.fastModel = selectedFastModel;
+  if (Object.keys(agentOverrides).length > 0) {
+    newConfig.agents = agentOverrides;
   }
   if (org !== undefined) newConfig.org = org;
   if (project !== undefined) newConfig.project = project;
@@ -264,7 +283,17 @@ export async function runInteractiveConfigWizard(configDir?: string): Promise<vo
   log.info(chalk.bold("Configuration summary:"));
   for (const [key, value] of Object.entries(newConfig)) {
     if (value !== undefined) {
-      console.log(`  ${chalk.cyan(key)} = ${value}`);
+      if (key === "agents" && typeof value === "object") {
+        console.log(`  ${chalk.cyan("agents")}:`);
+        for (const [role, cfg] of Object.entries(value as Record<string, AgentConfig>)) {
+          const parts: string[] = [];
+          if (cfg.provider) parts.push(`provider=${cfg.provider}`);
+          if (cfg.model) parts.push(`model=${cfg.model}`);
+          console.log(`    ${chalk.cyan(role)} = ${parts.join(", ")}`);
+        }
+      } else {
+        console.log(`  ${chalk.cyan(key)} = ${value}`);
+      }
     }
   }
   if (selectedSource === "auto") {

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,17 @@ import { PROVIDER_NAMES } from "./providers/index.js";
 import { DATASOURCE_NAMES } from "./datasources/index.js";
 import type { ProviderName } from "./providers/interface.js";
 import type { DatasourceName } from "./datasources/interface.js";
+import type { AgentName } from "./agents/interface.js";
 import { runInteractiveConfigWizard } from "./config-prompts.js";
+
+/**
+ * Per-agent provider/model override.
+ * Missing fields inherit from the top-level `provider`/`model`.
+ */
+export interface AgentConfig {
+  provider?: ProviderName;
+  model?: string;
+}
 
 /**
  * Persistent configuration options for Dispatch.
@@ -49,6 +59,24 @@ export interface DispatchConfig {
   workItemType?: string;
   iteration?: string;
   area?: string;
+  /**
+   * Per-agent provider/model overrides. Each agent role can independently
+   * specify a provider and model. Missing fields inherit from the top-level
+   * `provider`/`model` (or `fastProvider`/`fastModel` for planner/commit).
+   *
+   * Example:
+   * ```json
+   * {
+   *   "provider": "claude",
+   *   "model": "claude-sonnet-4",
+   *   "agents": {
+   *     "planner": { "provider": "copilot", "model": "claude-haiku-4" },
+   *     "commit": { "model": "claude-haiku-4" }
+   *   }
+   * }
+   * ```
+   */
+  agents?: Partial<Record<AgentName, AgentConfig>>;
   /** Short username prefix for branch names (e.g. "pr" instead of "patrick-ruddiman"). */
   username?: string;
   /** Internal auto-increment counter for MD datasource issue IDs. Defaults to 1 when absent. */
@@ -66,7 +94,7 @@ export const CONFIG_BOUNDS = {
 } as const;
 
 /** Valid configuration key names. */
-export const CONFIG_KEYS = ["provider", "model", "fastProvider", "fastModel", "source", "testTimeout", "planTimeout", "specTimeout", "specWarnTimeout", "specKillTimeout", "concurrency", "org", "project", "workItemType", "iteration", "area", "username"] as const;
+export const CONFIG_KEYS = ["provider", "model", "fastProvider", "fastModel", "agents", "source", "testTimeout", "planTimeout", "specTimeout", "specWarnTimeout", "specKillTimeout", "concurrency", "org", "project", "workItemType", "iteration", "area", "username"] as const;
 
 /** A valid configuration key name. */
 export type ConfigKey = (typeof CONFIG_KEYS)[number];
@@ -132,6 +160,11 @@ export function validateConfigValue(key: ConfigKey, value: string): string | nul
       if (!PROVIDER_NAMES.includes(value as ProviderName)) {
         return `Invalid fastProvider "${value}". Available: ${PROVIDER_NAMES.join(", ")}`;
       }
+      return null;
+
+    case "agents":
+      // agents is an object, not a scalar — skip string-level validation.
+      // Structural validation happens at load time.
       return null;
 
     case "source":
@@ -215,6 +248,38 @@ export function validateConfigValue(key: ConfigKey, value: string): string | nul
       return `Unknown config key "${key}"`;
   }
 }
+
+/** Valid agent role names for per-agent config. */
+const AGENT_NAMES: AgentName[] = ["planner", "executor", "spec", "commit"];
+
+/** Agent roles that default to the fast tier when fastProvider/fastModel are set. */
+const FAST_ROLES: AgentName[] = ["planner", "commit"];
+
+/**
+ * Resolve the effective provider+model for a given agent role.
+ *
+ * Priority: `agents.<role>` > `fastProvider`/`fastModel` (planner/commit only) > top-level.
+ */
+export function resolveAgentProviderConfig(
+  role: AgentName,
+  opts: {
+    provider: ProviderName;
+    model?: string;
+    fastProvider?: ProviderName;
+    fastModel?: string;
+    agents?: Partial<Record<AgentName, AgentConfig>>;
+  },
+): { provider: ProviderName; model?: string } {
+  const override = opts.agents?.[role];
+  const isFastRole = FAST_ROLES.includes(role);
+  return {
+    provider: override?.provider ?? (isFastRole ? opts.fastProvider : undefined) ?? opts.provider,
+    model: override?.model ?? (isFastRole ? opts.fastModel : undefined) ?? opts.model,
+  };
+}
+
+/** All valid agent role names. Exported for config wizard use. */
+export { AGENT_NAMES };
 
 /**
  * Handle the `dispatch config` subcommand.

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,8 +23,20 @@ export interface DispatchConfig {
    *   - Copilot: bare model ID (e.g. "claude-sonnet-4-5")
    *   - OpenCode: "provider/model" (e.g. "anthropic/claude-sonnet-4")
    * When omitted the provider uses its auto-detected default.
+   * This is the "strong" tier model used by executor and spec agents.
    */
   model?: string;
+  /**
+   * Provider for the "fast" (cost-saving) tier used by planner and commit agents.
+   * Defaults to `provider` when omitted.
+   */
+  fastProvider?: ProviderName;
+  /**
+   * Model for the "fast" (cost-saving) tier, in provider-specific format.
+   * Used by planner and commit agents to reduce costs.
+   * Defaults to `model` when omitted.
+   */
+  fastModel?: string;
   source?: DatasourceName;
   testTimeout?: number;
   planTimeout?: number;
@@ -54,7 +66,7 @@ export const CONFIG_BOUNDS = {
 } as const;
 
 /** Valid configuration key names. */
-export const CONFIG_KEYS = ["provider", "model", "source", "testTimeout", "planTimeout", "specTimeout", "specWarnTimeout", "specKillTimeout", "concurrency", "org", "project", "workItemType", "iteration", "area", "username"] as const;
+export const CONFIG_KEYS = ["provider", "model", "fastProvider", "fastModel", "source", "testTimeout", "planTimeout", "specTimeout", "specWarnTimeout", "specKillTimeout", "concurrency", "org", "project", "workItemType", "iteration", "area", "username"] as const;
 
 /** A valid configuration key name. */
 export type ConfigKey = (typeof CONFIG_KEYS)[number];
@@ -110,8 +122,15 @@ export function validateConfigValue(key: ConfigKey, value: string): string | nul
       return null;
 
     case "model":
+    case "fastModel":
       if (!value || value.trim() === "") {
-        return `Invalid model: value must not be empty`;
+        return `Invalid ${key}: value must not be empty`;
+      }
+      return null;
+
+    case "fastProvider":
+      if (!PROVIDER_NAMES.includes(value as ProviderName)) {
+        return `Invalid fastProvider "${value}". Available: ${PROVIDER_NAMES.join(", ")}`;
       }
       return null;
 

--- a/src/orchestrator/cli-config.ts
+++ b/src/orchestrator/cli-config.ts
@@ -25,6 +25,8 @@ import { detectDatasource, DATASOURCE_NAMES } from "../datasources/index.js";
 const CONFIG_TO_CLI: Record<ConfigKey, keyof RawCliArgs> = {
   provider: "provider",
   model: "model",
+  fastProvider: "fastProvider",
+  fastModel: "fastModel",
   source: "issueSource",
   testTimeout: "testTimeout",
   planTimeout: "planTimeout",

--- a/src/orchestrator/cli-config.ts
+++ b/src/orchestrator/cli-config.ts
@@ -27,6 +27,7 @@ const CONFIG_TO_CLI: Record<ConfigKey, keyof RawCliArgs> = {
   model: "model",
   fastProvider: "fastProvider",
   fastModel: "fastModel",
+  agents: "agents",
   source: "issueSource",
   testTimeout: "testTimeout",
   planTimeout: "planTimeout",

--- a/src/orchestrator/dispatch-pipeline.ts
+++ b/src/orchestrator/dispatch-pipeline.ts
@@ -20,8 +20,9 @@ import { registerCleanup } from "../helpers/cleanup.js";
 import { createWorktree, removeWorktree, worktreeName, generateFeatureBranchName } from "../helpers/worktree.js";
 import { isValidBranchName } from "../helpers/branch-validation.js";
 import { createTui, type TuiState } from "../tui.js";
-import type { ProviderName, ProviderInstance } from "../providers/interface.js";
-import { bootProvider } from "../providers/index.js";
+import type { ProviderName } from "../providers/interface.js";
+import { ProviderPool, type PoolEntry } from "../providers/pool.js";
+import { resolveAgentProviderConfig } from "../config.js";
 import { getDatasource } from "../datasources/index.js";
 import type { DatasourceName, DispatchLifecycleOptions, IssueDetails, IssueFetchOptions } from "../datasources/interface.js";
 import { ensureAuthReady, setAuthPromptHandler } from "../helpers/auth.js";
@@ -109,6 +110,7 @@ export async function runDispatchPipeline(
     model,
     fastProvider,
     fastModel,
+    agents,
     source,
     org,
     project,
@@ -122,10 +124,40 @@ export async function runDispatchPipeline(
   } = opts;
   let noBranch = noBranchOpt;
 
-  // Resolve fast tier — defaults to strong tier when not configured
-  const resolvedFastProvider = fastProvider ?? provider;
-  const resolvedFastModel = fastModel ?? model;
-  const needsFastInstance = resolvedFastProvider !== provider || resolvedFastModel !== model;
+  // Resolve per-agent provider+model configs
+  const configOpts = { provider, model, fastProvider, fastModel, agents };
+  const agentConfigs = {
+    planner: resolveAgentProviderConfig("planner", configOpts),
+    executor: resolveAgentProviderConfig("executor", configOpts),
+    commit: resolveAgentProviderConfig("commit", configOpts),
+  };
+
+  // Collect all unique provider+model combos as fallback entries for pools
+  const seen = new Set<string>();
+  const allEntries: PoolEntry[] = [];
+  let priority = 0;
+  for (const cfg of Object.values(agentConfigs)) {
+    const key = `${cfg.provider}:${cfg.model ?? "default"}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      allEntries.push({ provider: cfg.provider, model: cfg.model, priority: priority++ });
+    }
+  }
+
+  /**
+   * Create a ProviderPool for an agent, with its configured provider as primary
+   * and all other configured providers as fallbacks.
+   */
+  function createPool(primary: { provider: ProviderName; model?: string }, bootCwd: string): ProviderPool {
+    const primaryKey = `${primary.provider}:${primary.model ?? "default"}`;
+    const entries: PoolEntry[] = [
+      { provider: primary.provider, model: primary.model, priority: 0 },
+      ...allEntries
+        .filter((e) => `${e.provider}:${e.model ?? "default"}` !== primaryKey)
+        .map((e, i) => ({ ...e, priority: i + 1 })),
+    ];
+    return new ProviderPool({ entries, bootOpts: { url: serverUrl, cwd: bootCwd } });
+  }
 
   // Planning timeout/retry defaults
   const resolvedRetries = retries ?? DEFAULT_RETRY_COUNT;
@@ -295,35 +327,34 @@ export async function runDispatchPipeline(
     if (verbose && serverUrl) log.debug(`Server URL: ${serverUrl}`);
 
     // When using worktrees, providers are booted per-worktree inside
-    // processIssueFile. Otherwise, boot a single shared provider.
-    let instance: ProviderInstance | undefined;
-    let fastInstance: ProviderInstance | undefined;
+    // processIssueFile. Otherwise, boot a single shared provider pool.
     let planner: PlannerAgent | null = null;
     let executor: ExecutorAgent | undefined;
     let commitAgent: CommitAgent | undefined;
+    const sharedPools: ProviderPool[] = [];
 
     if (!useWorktrees) {
-      // Strong tier (executor, spec)
-      instance = await bootProvider(provider, { url: serverUrl, cwd, model });
-      registerCleanup(() => instance!.cleanup());
-      if (instance.model) {
-        tui.state.model = instance.model;
-      }
-      if (verbose && instance.model) log.debug(`Model (strong): ${instance.model}`);
+      // Create per-agent pools with failover support
+      const executorPool = createPool(agentConfigs.executor, cwd);
+      const plannerPool = createPool(agentConfigs.planner, cwd);
+      const commitPool = createPool(agentConfigs.commit, cwd);
+      sharedPools.push(executorPool, plannerPool, commitPool);
+      for (const pool of sharedPools) registerCleanup(() => pool.cleanup());
 
-      // Fast tier (planner, commit) — only boot if different from strong
-      if (needsFastInstance) {
-        fastInstance = await bootProvider(resolvedFastProvider, { url: serverUrl, cwd, model: resolvedFastModel });
-        registerCleanup(() => fastInstance!.cleanup());
-        if (verbose && fastInstance.model) log.debug(`Model (fast): ${fastInstance.model}`);
-      } else {
-        fastInstance = instance;
+      // Populate TUI model display from executor pool's primary entry
+      if (executorPool.model) {
+        tui.state.model = executorPool.model;
+      }
+      if (verbose) {
+        log.debug(`Executor: ${agentConfigs.executor.provider}${agentConfigs.executor.model ? ` (${agentConfigs.executor.model})` : ""}`);
+        log.debug(`Planner: ${agentConfigs.planner.provider}${agentConfigs.planner.model ? ` (${agentConfigs.planner.model})` : ""}`);
+        log.debug(`Commit: ${agentConfigs.commit.provider}${agentConfigs.commit.model ? ` (${agentConfigs.commit.model})` : ""}`);
       }
 
       // ── 4. Boot planner agent (unless --no-plan) ────────────────
-      planner = noPlan ? null : await bootPlanner({ provider: fastInstance, cwd });
-      executor = await bootExecutor({ provider: instance, cwd });
-      commitAgent = await bootCommit({ provider: fastInstance, cwd });
+      planner = noPlan ? null : await bootPlanner({ provider: plannerPool, cwd });
+      executor = await bootExecutor({ provider: executorPool, cwd });
+      commitAgent = await bootCommit({ provider: commitPool, cwd });
     }
 
     // ── 5. Dispatch tasks ───────────────────────────────────────
@@ -471,36 +502,31 @@ export async function runDispatchPipeline(
         const issueLifecycleOpts: DispatchLifecycleOptions = { cwd: issueCwd, username: usernameOverride };
 
         fileLogger?.phase("Provider/agent boot");
-        let localInstance: ProviderInstance;
         let localPlanner: PlannerAgent | null;
         let localExecutor: ExecutorAgent;
         let localCommitAgent: CommitAgent;
 
         if (useWorktrees) {
-          // Strong tier
-          localInstance = await bootProvider(provider, { url: serverUrl, cwd: issueCwd, model });
-          registerCleanup(() => localInstance.cleanup());
-          if (localInstance.model && !tui.state.model) {
-            tui.state.model = localInstance.model;
-          }
-          if (verbose && localInstance.model) log.debug(`Model (strong): ${localInstance.model}`);
+          // Create per-agent pools for this worktree
+          const localExecutorPool = createPool(agentConfigs.executor, issueCwd);
+          const localPlannerPool = createPool(agentConfigs.planner, issueCwd);
+          const localCommitPool = createPool(agentConfigs.commit, issueCwd);
+          registerCleanup(() => localExecutorPool.cleanup());
+          registerCleanup(() => localPlannerPool.cleanup());
+          registerCleanup(() => localCommitPool.cleanup());
 
-          // Fast tier — only boot if different from strong
-          let localFastInstance: ProviderInstance;
-          if (needsFastInstance) {
-            localFastInstance = await bootProvider(resolvedFastProvider, { url: serverUrl, cwd: issueCwd, model: resolvedFastModel });
-            registerCleanup(() => localFastInstance.cleanup());
-            if (verbose && localFastInstance.model) log.debug(`Model (fast): ${localFastInstance.model}`);
-          } else {
-            localFastInstance = localInstance;
+          if (!tui.state.model && localExecutorPool.model) {
+            tui.state.model = localExecutorPool.model;
+          }
+          if (verbose) {
+            log.debug(`Worktree executor: ${agentConfigs.executor.provider}${agentConfigs.executor.model ? ` (${agentConfigs.executor.model})` : ""}`);
           }
 
-          localPlanner = noPlan ? null : await bootPlanner({ provider: localFastInstance, cwd: issueCwd });
-          localExecutor = await bootExecutor({ provider: localInstance, cwd: issueCwd });
-          localCommitAgent = await bootCommit({ provider: localFastInstance, cwd: issueCwd });
-          fileLogger?.info(`Provider booted: ${localInstance.model ?? provider}${needsFastInstance ? ` (fast: ${localFastInstance.model ?? resolvedFastProvider})` : ""}`);
+          localPlanner = noPlan ? null : await bootPlanner({ provider: localPlannerPool, cwd: issueCwd });
+          localExecutor = await bootExecutor({ provider: localExecutorPool, cwd: issueCwd });
+          localCommitAgent = await bootCommit({ provider: localCommitPool, cwd: issueCwd });
+          fileLogger?.info(`Provider pools booted: executor=${agentConfigs.executor.provider}, planner=${agentConfigs.planner.provider}, commit=${agentConfigs.commit.provider}`);
         } else {
-          localInstance = instance!;
           localPlanner = planner;
           localExecutor = executor!;
           localCommitAgent = commitAgent!;
@@ -731,9 +757,7 @@ export async function runDispatchPipeline(
             }
           }
 
-          if (!tui.state.model && localInstance.model) {
-            tui.state.model = localInstance.model;
-          }
+          // TUI model is populated at pool creation time
 
           if (stopAfterIssue) break;
         }
@@ -890,7 +914,6 @@ export async function runDispatchPipeline(
         if (useWorktrees) {
           await localExecutor.cleanup();
           await localPlanner?.cleanup();
-          await localInstance.cleanup();
         }
 
         return { halted: stopAfterIssue };
@@ -985,7 +1008,7 @@ export async function runDispatchPipeline(
     await commitAgent?.cleanup();
     await executor?.cleanup();
     await planner?.cleanup();
-    await instance?.cleanup();
+    // Pool cleanup is handled via registerCleanup() above
 
     const completed = results.filter((result) => result.success).length;
     const failed = results.filter((result) => !result.success).length;

--- a/src/orchestrator/dispatch-pipeline.ts
+++ b/src/orchestrator/dispatch-pipeline.ts
@@ -107,6 +107,8 @@ export async function runDispatchPipeline(
     feature,
     provider = "opencode",
     model,
+    fastProvider,
+    fastModel,
     source,
     org,
     project,
@@ -119,6 +121,11 @@ export async function runDispatchPipeline(
     username: usernameOverride,
   } = opts;
   let noBranch = noBranchOpt;
+
+  // Resolve fast tier — defaults to strong tier when not configured
+  const resolvedFastProvider = fastProvider ?? provider;
+  const resolvedFastModel = fastModel ?? model;
+  const needsFastInstance = resolvedFastProvider !== provider || resolvedFastModel !== model;
 
   // Planning timeout/retry defaults
   const resolvedRetries = retries ?? DEFAULT_RETRY_COUNT;
@@ -290,22 +297,33 @@ export async function runDispatchPipeline(
     // When using worktrees, providers are booted per-worktree inside
     // processIssueFile. Otherwise, boot a single shared provider.
     let instance: ProviderInstance | undefined;
+    let fastInstance: ProviderInstance | undefined;
     let planner: PlannerAgent | null = null;
     let executor: ExecutorAgent | undefined;
     let commitAgent: CommitAgent | undefined;
 
     if (!useWorktrees) {
+      // Strong tier (executor, spec)
       instance = await bootProvider(provider, { url: serverUrl, cwd, model });
       registerCleanup(() => instance!.cleanup());
       if (instance.model) {
         tui.state.model = instance.model;
       }
-      if (verbose && instance.model) log.debug(`Model: ${instance.model}`);
+      if (verbose && instance.model) log.debug(`Model (strong): ${instance.model}`);
+
+      // Fast tier (planner, commit) — only boot if different from strong
+      if (needsFastInstance) {
+        fastInstance = await bootProvider(resolvedFastProvider, { url: serverUrl, cwd, model: resolvedFastModel });
+        registerCleanup(() => fastInstance!.cleanup());
+        if (verbose && fastInstance.model) log.debug(`Model (fast): ${fastInstance.model}`);
+      } else {
+        fastInstance = instance;
+      }
 
       // ── 4. Boot planner agent (unless --no-plan) ────────────────
-      planner = noPlan ? null : await bootPlanner({ provider: instance, cwd });
+      planner = noPlan ? null : await bootPlanner({ provider: fastInstance, cwd });
       executor = await bootExecutor({ provider: instance, cwd });
-      commitAgent = await bootCommit({ provider: instance, cwd });
+      commitAgent = await bootCommit({ provider: fastInstance, cwd });
     }
 
     // ── 5. Dispatch tasks ───────────────────────────────────────
@@ -459,16 +477,28 @@ export async function runDispatchPipeline(
         let localCommitAgent: CommitAgent;
 
         if (useWorktrees) {
+          // Strong tier
           localInstance = await bootProvider(provider, { url: serverUrl, cwd: issueCwd, model });
           registerCleanup(() => localInstance.cleanup());
           if (localInstance.model && !tui.state.model) {
             tui.state.model = localInstance.model;
           }
-          if (verbose && localInstance.model) log.debug(`Model: ${localInstance.model}`);
-          localPlanner = noPlan ? null : await bootPlanner({ provider: localInstance, cwd: issueCwd });
+          if (verbose && localInstance.model) log.debug(`Model (strong): ${localInstance.model}`);
+
+          // Fast tier — only boot if different from strong
+          let localFastInstance: ProviderInstance;
+          if (needsFastInstance) {
+            localFastInstance = await bootProvider(resolvedFastProvider, { url: serverUrl, cwd: issueCwd, model: resolvedFastModel });
+            registerCleanup(() => localFastInstance.cleanup());
+            if (verbose && localFastInstance.model) log.debug(`Model (fast): ${localFastInstance.model}`);
+          } else {
+            localFastInstance = localInstance;
+          }
+
+          localPlanner = noPlan ? null : await bootPlanner({ provider: localFastInstance, cwd: issueCwd });
           localExecutor = await bootExecutor({ provider: localInstance, cwd: issueCwd });
-          localCommitAgent = await bootCommit({ provider: localInstance, cwd: issueCwd });
-          fileLogger?.info(`Provider booted: ${localInstance.model ?? provider}`);
+          localCommitAgent = await bootCommit({ provider: localFastInstance, cwd: issueCwd });
+          fileLogger?.info(`Provider booted: ${localInstance.model ?? provider}${needsFastInstance ? ` (fast: ${localFastInstance.model ?? resolvedFastProvider})` : ""}`);
         } else {
           localInstance = instance!;
           localPlanner = planner;

--- a/src/orchestrator/runner.ts
+++ b/src/orchestrator/runner.ts
@@ -32,6 +32,10 @@ export interface OrchestrateRunOptions {
   provider?: ProviderName;
   /** Model override to pass to the provider (provider-specific format). */
   model?: string;
+  /** Provider for the fast (cost-saving) tier — used by planner and commit agents. */
+  fastProvider?: ProviderName;
+  /** Model for the fast (cost-saving) tier (provider-specific format). */
+  fastModel?: string;
   serverUrl?: string;
   source?: DatasourceName;
   org?: string;
@@ -59,6 +63,10 @@ export interface RawCliArgs {
   provider: ProviderName;
   /** Model override from config or CLI (provider-specific format). */
   model?: string;
+  /** Provider for the fast (cost-saving) tier — used by planner and commit agents. */
+  fastProvider?: ProviderName;
+  /** Model for the fast (cost-saving) tier (provider-specific format). */
+  fastModel?: string;
   serverUrl?: string;
   cwd: string;
   verbose: boolean;
@@ -381,7 +389,8 @@ export async function boot(opts: AgentBootOptions): Promise<OrchestratorAgent> {
       return this.orchestrate({
         issueIds: m.issueIds, concurrency: m.concurrency ?? defaultConcurrency(),
         dryRun: m.dryRun, noPlan: m.noPlan, noBranch: m.noBranch, noWorktree: m.noWorktree, provider: m.provider,
-        model: m.model, serverUrl: m.serverUrl, source: m.issueSource, org: m.org, project: m.project,
+        model: m.model, fastProvider: m.fastProvider, fastModel: m.fastModel,
+        serverUrl: m.serverUrl, source: m.issueSource, org: m.org, project: m.project,
         workItemType: m.workItemType, iteration: m.iteration, area: m.area, planTimeout: m.planTimeout, planRetries: m.planRetries, retries: m.retries,
         force: m.force, feature: m.feature, username: m.username,
       });

--- a/src/orchestrator/runner.ts
+++ b/src/orchestrator/runner.ts
@@ -5,6 +5,8 @@
 import type { DispatchResult } from "../dispatcher.js";
 import type { AgentBootOptions } from "../agents/interface.js";
 import type { ProviderName } from "../providers/interface.js";
+import type { AgentConfig } from "../config.js";
+import type { AgentName } from "../agents/interface.js";
 import type { DatasourceName } from "../datasources/interface.js";
 import type { SpecOptions, SpecSummary } from "../spec-generator.js";
 import { defaultConcurrency, DEFAULT_SPEC_TIMEOUT_MIN, resolveSource } from "../spec-generator.js";
@@ -36,6 +38,8 @@ export interface OrchestrateRunOptions {
   fastProvider?: ProviderName;
   /** Model for the fast (cost-saving) tier (provider-specific format). */
   fastModel?: string;
+  /** Per-agent provider/model overrides. Supersedes fastProvider/fastModel when set. */
+  agents?: Partial<Record<AgentName, AgentConfig>>;
   serverUrl?: string;
   source?: DatasourceName;
   org?: string;
@@ -67,6 +71,8 @@ export interface RawCliArgs {
   fastProvider?: ProviderName;
   /** Model for the fast (cost-saving) tier (provider-specific format). */
   fastModel?: string;
+  /** Per-agent provider/model overrides. Supersedes fastProvider/fastModel when set. */
+  agents?: Partial<Record<AgentName, AgentConfig>>;
   serverUrl?: string;
   cwd: string;
   verbose: boolean;
@@ -389,7 +395,7 @@ export async function boot(opts: AgentBootOptions): Promise<OrchestratorAgent> {
       return this.orchestrate({
         issueIds: m.issueIds, concurrency: m.concurrency ?? defaultConcurrency(),
         dryRun: m.dryRun, noPlan: m.noPlan, noBranch: m.noBranch, noWorktree: m.noWorktree, provider: m.provider,
-        model: m.model, fastProvider: m.fastProvider, fastModel: m.fastModel,
+        model: m.model, fastProvider: m.fastProvider, fastModel: m.fastModel, agents: m.agents,
         serverUrl: m.serverUrl, source: m.issueSource, org: m.org, project: m.project,
         workItemType: m.workItemType, iteration: m.iteration, area: m.area, planTimeout: m.planTimeout, planRetries: m.planRetries, retries: m.retries,
         force: m.force, feature: m.feature, username: m.username,

--- a/src/orchestrator/spec-pipeline.ts
+++ b/src/orchestrator/spec-pipeline.ts
@@ -413,6 +413,7 @@ async function generateSpecsBatch(
         fileLoggerStorage.getStore()?.phase("Datasource sync");
         if (tuiTask) {
           tuiTask.status = "syncing";
+          tuiTask.elapsed = Date.now();
           tuiTask.feedback = undefined;
           tuiUpdate?.();
         }

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -21,16 +21,31 @@ import { log } from "../helpers/logger.js";
 /**
  * List available Claude models.
  *
- * The Claude Agent SDK does not expose a model listing API, so this returns
- * a hardcoded list of known Claude model identifiers.
+ * Creates a temporary session to query the SDK for supported models.
+ * Falls back to a hardcoded list if the dynamic query fails.
  */
-export async function listModels(_opts?: ProviderBootOptions): Promise<string[]> {
-  return [
-    "claude-haiku-3-5",
-    "claude-opus-4-6",
-    "claude-sonnet-4",
-    "claude-sonnet-4-5",
-  ];
+export async function listModels(opts?: ProviderBootOptions): Promise<string[]> {
+  try {
+    const session = unstable_v2_createSession({
+      model: opts?.model ?? "claude-sonnet-4",
+      permissionMode: "bypassPermissions" as const,
+      allowDangerouslySkipPermissions: true,
+    });
+    try {
+      const models = await session.supportedModels();
+      return models.map((m) => m.value).sort();
+    } finally {
+      session.close();
+    }
+  } catch (err) {
+    log.debug(`Failed to list models dynamically: ${log.formatErrorChain(err)}`);
+    return [
+      "claude-haiku-3-5",
+      "claude-opus-4-6",
+      "claude-sonnet-4",
+      "claude-sonnet-4-5",
+    ];
+  }
 }
 
 /**

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -9,7 +9,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { unstable_v2_createSession, type SDKSession } from "@anthropic-ai/claude-agent-sdk";
+import { query, unstable_v2_createSession, type Options, type ModelInfo, type SDKSession } from "@anthropic-ai/claude-agent-sdk";
 import type {
   ProviderInstance,
   ProviderBootOptions,
@@ -21,21 +21,22 @@ import { log } from "../helpers/logger.js";
 /**
  * List available Claude models.
  *
- * Creates a temporary session to query the SDK for supported models.
+ * Uses the V1 query() API to ask the SDK for supported models at runtime.
  * Falls back to a hardcoded list if the dynamic query fails.
  */
 export async function listModels(opts?: ProviderBootOptions): Promise<string[]> {
   try {
-    const session = unstable_v2_createSession({
+    const queryOpts: Options = {
       model: opts?.model ?? "claude-sonnet-4",
-      permissionMode: "bypassPermissions" as const,
+      permissionMode: "bypassPermissions",
       allowDangerouslySkipPermissions: true,
-    });
+    };
+    const q = query({ prompt: "", options: queryOpts });
     try {
-      const models = await session.supportedModels();
-      return models.map((m) => m.value).sort();
+      const models = await q.supportedModels();
+      return models.map((m: ModelInfo) => m.value).sort();
     } finally {
-      session.close();
+      q.close();
     }
   } catch (err) {
     log.debug(`Failed to list models dynamically: ${log.formatErrorChain(err)}`);

--- a/src/providers/errors.ts
+++ b/src/providers/errors.ts
@@ -1,0 +1,22 @@
+/**
+ * Provider error classification utilities.
+ *
+ * Provides heuristic-based detection of throttle/rate-limit errors from
+ * provider SDKs. All four providers surface errors as `throw new Error(msg)`
+ * with messages containing HTTP status codes or human-readable throttle language.
+ */
+
+/**
+ * Detect whether an error indicates throttling or rate-limiting by the provider.
+ *
+ * Uses pattern matching on error messages since provider SDKs don't expose
+ * structured error codes. Covers common patterns across OpenAI-style APIs (429),
+ * Copilot SDK error events, Claude API errors, and generic service unavailability.
+ *
+ * False positive = unnecessary failover (costs a retry, not data loss).
+ * False negative = existing `withRetry` handles it (3 retries on any error).
+ */
+export function isThrottleError(err: unknown): boolean {
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return /rate.limit|429|503|throttl|capacity|overloaded|too many requests|service unavailable/.test(msg);
+}

--- a/src/providers/pool.ts
+++ b/src/providers/pool.ts
@@ -1,0 +1,174 @@
+/**
+ * ProviderPool — a transparent failover wrapper that implements ProviderInstance.
+ *
+ * Agents receive a pool instead of a raw provider instance. The pool routes
+ * requests to the cheapest available provider and automatically fails over
+ * to alternatives when throttling is detected.
+ *
+ * Key design decisions:
+ *   - Lazy boots: only the primary provider is booted upfront; fallbacks are
+ *     booted on first failover to avoid wasting resources.
+ *   - Cooldowns: throttled providers are skipped for a configurable period.
+ *   - Session tracking: maps session IDs to owning instances so prompt()
+ *     calls route correctly.
+ *   - Single-entry pool: identical behavior to a bare ProviderInstance —
+ *     zero overhead for users who don't configure fallbacks.
+ */
+
+import type { ProviderName, ProviderInstance, ProviderBootOptions, ProviderPromptOptions } from "./interface.js";
+import { bootProvider } from "./index.js";
+import { isThrottleError } from "./errors.js";
+import { log } from "../helpers/logger.js";
+
+/** A provider+model entry in the pool, ordered by priority. */
+export interface PoolEntry {
+  /** Provider name (e.g. "copilot", "claude") */
+  provider: ProviderName;
+  /** Model override in provider-specific format */
+  model?: string;
+  /** Lower = preferred (cheaper). Entries are tried in priority order. */
+  priority: number;
+}
+
+/** Options for constructing a ProviderPool. */
+export interface ProviderPoolOptions {
+  /** Provider entries ordered by priority (cheapest first). */
+  entries: PoolEntry[];
+  /** Boot options shared by all providers (url, cwd). Model is per-entry. */
+  bootOpts: Omit<ProviderBootOptions, "model">;
+  /** How long (ms) to avoid a throttled provider. Default: 60000. */
+  cooldownMs?: number;
+}
+
+/** Generate a deduplication key for a provider+model combo. */
+function entryKey(provider: ProviderName, model?: string): string {
+  return `${provider}:${model ?? "default"}`;
+}
+
+/**
+ * A pool of providers that implements ProviderInstance with transparent failover.
+ *
+ * Agents use this exactly like a normal provider — they never know about
+ * the pool or failover mechanics.
+ */
+export class ProviderPool implements ProviderInstance {
+  readonly name: string;
+  readonly model?: string;
+
+  private instances = new Map<string, ProviderInstance>();
+  private cooldowns = new Map<string, number>();
+  private sessionOwner = new Map<string, { instance: ProviderInstance; key: string }>();
+  private entries: PoolEntry[];
+  private bootOpts: Omit<ProviderBootOptions, "model">;
+  private cooldownMs: number;
+
+  constructor(opts: ProviderPoolOptions) {
+    if (opts.entries.length === 0) {
+      throw new Error("ProviderPool requires at least one entry");
+    }
+    // Sort by priority (stable sort preserves insertion order for equal priorities)
+    this.entries = [...opts.entries].sort((a, b) => a.priority - b.priority);
+    this.bootOpts = opts.bootOpts;
+    this.cooldownMs = opts.cooldownMs ?? 60_000;
+
+    // Name and model reflect the primary (highest-priority) entry
+    const primary = this.entries[0];
+    this.name = primary.provider;
+    this.model = primary.model;
+  }
+
+  /**
+   * Get the best available provider instance (not cooled down).
+   * Boots the provider lazily if not yet started.
+   */
+  private async getProvider(excludeKey?: string): Promise<{ instance: ProviderInstance; key: string }> {
+    const now = Date.now();
+
+    for (const entry of this.entries) {
+      const key = entryKey(entry.provider, entry.model);
+
+      // Skip if this is the excluded provider (the one that just failed)
+      if (key === excludeKey) continue;
+
+      // Skip if still in cooldown
+      const cooldownUntil = this.cooldowns.get(key);
+      if (cooldownUntil && now < cooldownUntil) continue;
+
+      // Boot if not yet started
+      if (!this.instances.has(key)) {
+        log.debug(`Pool: booting ${entry.provider}${entry.model ? ` (${entry.model})` : ""}`);
+        const instance = await bootProvider(entry.provider, {
+          ...this.bootOpts,
+          model: entry.model,
+        });
+        this.instances.set(key, instance);
+      }
+
+      return { instance: this.instances.get(key)!, key };
+    }
+
+    throw new Error("ProviderPool: all providers are throttled or unavailable");
+  }
+
+  /** Mark a provider as throttled — it will be skipped until cooldown expires. */
+  private markThrottled(key: string): void {
+    this.cooldowns.set(key, Date.now() + this.cooldownMs);
+    log.debug(`Pool: marked ${key} as throttled for ${this.cooldownMs}ms`);
+  }
+
+  async createSession(): Promise<string> {
+    const { instance, key } = await this.getProvider();
+    const sessionId = await instance.createSession();
+    this.sessionOwner.set(sessionId, { instance, key });
+    return sessionId;
+  }
+
+  async prompt(
+    sessionId: string,
+    text: string,
+    options?: ProviderPromptOptions,
+  ): Promise<string | null> {
+    const owner = this.sessionOwner.get(sessionId);
+    if (!owner) {
+      throw new Error(`ProviderPool: session "${sessionId}" not found`);
+    }
+
+    try {
+      return await owner.instance.prompt(sessionId, text, options);
+    } catch (err) {
+      // Only failover on throttle errors — all other errors propagate normally
+      if (!isThrottleError(err) || this.entries.length <= 1) {
+        throw err;
+      }
+
+      log.debug(`Pool: throttle detected on ${owner.key}, failing over...`);
+      this.markThrottled(owner.key);
+
+      // Get next available provider (excluding the one that just failed)
+      const fallback = await this.getProvider(owner.key);
+
+      // Create a new session on the fallback and retry the prompt
+      const newSessionId = await fallback.instance.createSession();
+      // Remap the original session ID to the fallback so any future calls route correctly
+      this.sessionOwner.set(sessionId, fallback);
+
+      return fallback.instance.prompt(newSessionId, text, options);
+    }
+  }
+
+  async send(sessionId: string, text: string): Promise<void> {
+    const owner = this.sessionOwner.get(sessionId);
+    if (!owner) return;
+    if (owner.instance.send) {
+      await owner.instance.send(sessionId, text);
+    }
+  }
+
+  async cleanup(): Promise<void> {
+    const cleanups = [...this.instances.values()].map((i) => i.cleanup());
+    await Promise.allSettled(cleanups);
+    this.instances.clear();
+    this.sessionOwner.clear();
+    this.cooldowns.clear();
+  }
+}

--- a/src/tests/claude.test.ts
+++ b/src/tests/claude.test.ts
@@ -2,17 +2,23 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ─── Hoisted mock references ────────────────────────────────────────
 
-const { mockCreateSession, mockSession } = vi.hoisted(() => {
+const { mockQuery, mockQueryFn, mockCreateSession, mockSession } = vi.hoisted(() => {
+  const mockQuery = {
+    supportedModels: vi.fn().mockResolvedValue([]),
+    close: vi.fn(),
+  };
+
+  const mockQueryFn = vi.fn().mockReturnValue(mockQuery);
+
   const mockSession = {
     send: vi.fn().mockResolvedValue(undefined),
     stream: vi.fn().mockReturnValue((async function* () {})()),
     close: vi.fn(),
-    supportedModels: vi.fn().mockResolvedValue([]),
   };
 
   const mockCreateSession = vi.fn().mockReturnValue(mockSession);
 
-  return { mockCreateSession, mockSession };
+  return { mockQuery, mockQueryFn, mockCreateSession, mockSession };
 });
 
 const { mockRandomUUID } = vi.hoisted(() => {
@@ -27,6 +33,7 @@ vi.mock("node:crypto", () => ({
 }));
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: mockQueryFn,
   unstable_v2_createSession: mockCreateSession,
 }));
 
@@ -49,18 +56,20 @@ import { randomUUID } from "node:crypto";
 beforeEach(() => {
   vi.clearAllMocks();
   mockRandomUUID.mockReturnValue("test-uuid-1234");
+  mockQueryFn.mockReturnValue(mockQuery);
+  mockQuery.supportedModels.mockResolvedValue([]);
+  mockQuery.close.mockReturnValue(undefined);
   mockCreateSession.mockReturnValue(mockSession);
   mockSession.send.mockResolvedValue(undefined);
   mockSession.stream.mockReturnValue((async function* () {})());
   mockSession.close.mockReturnValue(undefined);
-  mockSession.supportedModels.mockResolvedValue([]);
 });
 
 // ─── Tests ──────────────────────────────────────────────────────────
 
 describe("listModels", () => {
   it("returns sorted model values from supportedModels()", async () => {
-    mockSession.supportedModels.mockResolvedValue([
+    mockQuery.supportedModels.mockResolvedValue([
       { value: "claude-sonnet-4", displayName: "Sonnet 4", description: "" },
       { value: "claude-haiku-3-5", displayName: "Haiku 3.5", description: "" },
       { value: "claude-opus-4-6", displayName: "Opus 4.6", description: "" },
@@ -68,14 +77,14 @@ describe("listModels", () => {
 
     const models = await listModels();
     expect(models).toEqual(["claude-haiku-3-5", "claude-opus-4-6", "claude-sonnet-4"]);
-    expect(mockSession.close).toHaveBeenCalled();
+    expect(mockQuery.close).toHaveBeenCalled();
   });
 
-  it("closes the session even when supportedModels() throws", async () => {
-    mockSession.supportedModels.mockRejectedValue(new Error("fetch fail"));
+  it("closes the query even when supportedModels() throws", async () => {
+    mockQuery.supportedModels.mockRejectedValue(new Error("fetch fail"));
 
     const models = await listModels();
-    expect(mockSession.close).toHaveBeenCalled();
+    expect(mockQuery.close).toHaveBeenCalled();
     // Falls back to hardcoded list
     expect(models).toEqual([
       "claude-haiku-3-5",
@@ -85,9 +94,9 @@ describe("listModels", () => {
     ]);
   });
 
-  it("falls back to hardcoded list when session creation fails", async () => {
-    mockCreateSession.mockImplementation(() => {
-      throw new Error("session fail");
+  it("falls back to hardcoded list when query() throws", async () => {
+    mockQueryFn.mockImplementation(() => {
+      throw new Error("query fail");
     });
 
     const models = await listModels();

--- a/src/tests/claude.test.ts
+++ b/src/tests/claude.test.ts
@@ -7,6 +7,7 @@ const { mockCreateSession, mockSession } = vi.hoisted(() => {
     send: vi.fn().mockResolvedValue(undefined),
     stream: vi.fn().mockReturnValue((async function* () {})()),
     close: vi.fn(),
+    supportedModels: vi.fn().mockResolvedValue([]),
   };
 
   const mockCreateSession = vi.fn().mockReturnValue(mockSession);
@@ -40,7 +41,7 @@ vi.mock("../helpers/logger.js", () => ({
   },
 }));
 
-import { boot } from "../providers/claude.js";
+import { boot, listModels } from "../providers/claude.js";
 import { randomUUID } from "node:crypto";
 
 // ─── Reset mocks between tests ─────────────────────────────────────
@@ -52,9 +53,52 @@ beforeEach(() => {
   mockSession.send.mockResolvedValue(undefined);
   mockSession.stream.mockReturnValue((async function* () {})());
   mockSession.close.mockReturnValue(undefined);
+  mockSession.supportedModels.mockResolvedValue([]);
 });
 
 // ─── Tests ──────────────────────────────────────────────────────────
+
+describe("listModels", () => {
+  it("returns sorted model values from supportedModels()", async () => {
+    mockSession.supportedModels.mockResolvedValue([
+      { value: "claude-sonnet-4", displayName: "Sonnet 4", description: "" },
+      { value: "claude-haiku-3-5", displayName: "Haiku 3.5", description: "" },
+      { value: "claude-opus-4-6", displayName: "Opus 4.6", description: "" },
+    ]);
+
+    const models = await listModels();
+    expect(models).toEqual(["claude-haiku-3-5", "claude-opus-4-6", "claude-sonnet-4"]);
+    expect(mockSession.close).toHaveBeenCalled();
+  });
+
+  it("closes the session even when supportedModels() throws", async () => {
+    mockSession.supportedModels.mockRejectedValue(new Error("fetch fail"));
+
+    const models = await listModels();
+    expect(mockSession.close).toHaveBeenCalled();
+    // Falls back to hardcoded list
+    expect(models).toEqual([
+      "claude-haiku-3-5",
+      "claude-opus-4-6",
+      "claude-sonnet-4",
+      "claude-sonnet-4-5",
+    ]);
+  });
+
+  it("falls back to hardcoded list when session creation fails", async () => {
+    mockCreateSession.mockImplementation(() => {
+      throw new Error("session fail");
+    });
+
+    const models = await listModels();
+    expect(models).toEqual([
+      "claude-haiku-3-5",
+      "claude-opus-4-6",
+      "claude-sonnet-4",
+      "claude-sonnet-4-5",
+    ]);
+  });
+});
 
 describe("boot", () => {
   it("uses default model when no opts provided", async () => {

--- a/src/tests/cli.test.ts
+++ b/src/tests/cli.test.ts
@@ -817,4 +817,17 @@ describe("help text completeness", () => {
   it("documents paused rerun recovery for interactive dispatch help", () => {
     expect(HELP).toContain("Interactive dispatch runs pause exhausted failed tasks");
   });
+
+  it("documents dispatch config --cwd usage", () => {
+    expect(HELP).toContain("dispatch config --cwd");
+  });
+
+  it("documents config-file-only settings", () => {
+    expect(HELP).toContain("workItemType");
+    expect(HELP).toContain("username (branch prefix)");
+  });
+
+  it("shows --feature combined with issue IDs in examples", () => {
+    expect(HELP).toContain("dispatch 14 15 16 --feature my-feature");
+  });
 });

--- a/src/tests/config-prompts.test.ts
+++ b/src/tests/config-prompts.test.ts
@@ -75,7 +75,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("github");
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(saveConfig).toHaveBeenCalledWith(
@@ -96,7 +96,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("model-a")   // model
       .mockResolvedValueOnce("github");   // datasource
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(saveConfig).toHaveBeenCalledWith(
@@ -117,7 +117,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("")          // model — "default (provider decides)"
       .mockResolvedValueOnce("github");   // datasource
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     const savedConfig = vi.mocked(saveConfig).mock.calls[0][0];
@@ -143,7 +143,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("github");
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(false); // save — declined
     await runInteractiveConfigWizard();
     expect(saveConfig).not.toHaveBeenCalled();
@@ -156,7 +156,7 @@ describe("runInteractiveConfigWizard", () => {
     });
     vi.mocked(confirm)
       .mockResolvedValueOnce(true)  // reconfigure
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")
@@ -175,7 +175,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("github");
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(select).toHaveBeenCalledWith(
@@ -191,7 +191,7 @@ describe("runInteractiveConfigWizard", () => {
     vi.mocked(loadConfig).mockResolvedValueOnce({ source: "azdevops" });
     vi.mocked(confirm)
       .mockResolvedValueOnce(true)  // reconfigure
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")
@@ -212,7 +212,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("md");
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(select).toHaveBeenCalledWith(
@@ -229,7 +229,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("auto");
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     const savedConfig = vi.mocked(saveConfig).mock.calls[0][0];
@@ -243,7 +243,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("github");
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     const datasourceCall = vi.mocked(select).mock.calls[1][0];
@@ -257,7 +257,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("github");
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     const providerCall = vi.mocked(select).mock.calls[0][0];
@@ -280,7 +280,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("@CurrentIteration")             // iteration
       .mockResolvedValueOnce("MyProject\\Team A");            // area
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(saveConfig).toHaveBeenCalledWith(
@@ -309,7 +309,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("")   // iteration — skip
       .mockResolvedValueOnce("");  // area — skip
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     const savedConfig = vi.mocked(saveConfig).mock.calls[0][0];
@@ -337,7 +337,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("")                               // iteration — skip
       .mockResolvedValueOnce("");                              // area — skip
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     // Verify input was called with defaults from git remote
@@ -361,7 +361,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("github");
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(input).not.toHaveBeenCalled();
@@ -379,7 +379,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("github");
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     const providerCall = vi.mocked(select).mock.calls[0][0];
@@ -404,7 +404,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("copilot")   // provider
       .mockResolvedValueOnce("github");   // datasource
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(ensureAuthReady).toHaveBeenCalledWith("github", process.cwd(), undefined);
@@ -422,7 +422,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("")                               // iteration
       .mockResolvedValueOnce("");                              // area
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(ensureAuthReady).toHaveBeenCalledWith("azdevops", process.cwd(), "https://dev.azure.com/myorg");
@@ -434,7 +434,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("md");
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(ensureAuthReady).toHaveBeenCalledWith("md", process.cwd(), undefined);
@@ -447,7 +447,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("github");
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(saveConfig).toHaveBeenCalledWith(
@@ -463,7 +463,7 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("auto");    // auto selected, but detected as github
     vi.mocked(confirm)
-      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false) // per-agent overrides — decline
       .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(ensureAuthReady).toHaveBeenCalledWith("github", process.cwd(), undefined);

--- a/src/tests/config-prompts.test.ts
+++ b/src/tests/config-prompts.test.ts
@@ -74,7 +74,9 @@ describe("runInteractiveConfigWizard", () => {
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("github");
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(saveConfig).toHaveBeenCalledWith(
       expect.objectContaining({ provider: "copilot", source: "github" }),
@@ -93,7 +95,9 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("copilot")   // provider
       .mockResolvedValueOnce("model-a")   // model
       .mockResolvedValueOnce("github");   // datasource
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(saveConfig).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -112,7 +116,9 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("copilot")   // provider
       .mockResolvedValueOnce("")          // model — "default (provider decides)"
       .mockResolvedValueOnce("github");   // datasource
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     const savedConfig = vi.mocked(saveConfig).mock.calls[0][0];
     expect(savedConfig.provider).toBe("copilot");
@@ -136,7 +142,9 @@ describe("runInteractiveConfigWizard", () => {
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("github");
-    vi.mocked(confirm).mockResolvedValueOnce(false); // save — declined
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(false); // save — declined
     await runInteractiveConfigWizard();
     expect(saveConfig).not.toHaveBeenCalled();
   });
@@ -147,7 +155,8 @@ describe("runInteractiveConfigWizard", () => {
       source: "github",
     });
     vi.mocked(confirm)
-      .mockResolvedValueOnce(true) // reconfigure
+      .mockResolvedValueOnce(true)  // reconfigure
+      .mockResolvedValueOnce(false) // fast tier — decline
       .mockResolvedValueOnce(true); // save
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")
@@ -165,7 +174,9 @@ describe("runInteractiveConfigWizard", () => {
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("github");
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(select).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -179,7 +190,8 @@ describe("runInteractiveConfigWizard", () => {
     vi.mocked(detectDatasource).mockResolvedValueOnce("github");
     vi.mocked(loadConfig).mockResolvedValueOnce({ source: "azdevops" });
     vi.mocked(confirm)
-      .mockResolvedValueOnce(true) // reconfigure
+      .mockResolvedValueOnce(true)  // reconfigure
+      .mockResolvedValueOnce(false) // fast tier — decline
       .mockResolvedValueOnce(true); // save
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")
@@ -199,7 +211,9 @@ describe("runInteractiveConfigWizard", () => {
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("md");
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(select).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -214,7 +228,9 @@ describe("runInteractiveConfigWizard", () => {
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("auto");
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     const savedConfig = vi.mocked(saveConfig).mock.calls[0][0];
     expect(savedConfig.source).toBeUndefined();
@@ -226,7 +242,9 @@ describe("runInteractiveConfigWizard", () => {
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("github");
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     const datasourceCall = vi.mocked(select).mock.calls[1][0];
     expect(datasourceCall.choices[0]).toMatchObject({ name: "auto", value: "auto" });
@@ -238,7 +256,9 @@ describe("runInteractiveConfigWizard", () => {
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("github");
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     const providerCall = vi.mocked(select).mock.calls[0][0];
     for (const choice of providerCall.choices as Array<{ name: string; value: string }>) {
@@ -259,7 +279,9 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("User Story")                    // workItemType
       .mockResolvedValueOnce("@CurrentIteration")             // iteration
       .mockResolvedValueOnce("MyProject\\Team A");            // area
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(saveConfig).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -286,7 +308,9 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("")   // workItemType — skip
       .mockResolvedValueOnce("")   // iteration — skip
       .mockResolvedValueOnce("");  // area — skip
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     const savedConfig = vi.mocked(saveConfig).mock.calls[0][0];
     expect(savedConfig.org).toBeUndefined();
@@ -312,7 +336,9 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("")                               // workItemType — skip
       .mockResolvedValueOnce("")                               // iteration — skip
       .mockResolvedValueOnce("");                              // area — skip
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     // Verify input was called with defaults from git remote
     expect(input).toHaveBeenCalledWith(
@@ -334,7 +360,9 @@ describe("runInteractiveConfigWizard", () => {
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("github");
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(input).not.toHaveBeenCalled();
     const savedConfig = vi.mocked(saveConfig).mock.calls[0][0];
@@ -350,7 +378,9 @@ describe("runInteractiveConfigWizard", () => {
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("github");
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     const providerCall = vi.mocked(select).mock.calls[0][0];
     const choices = providerCall.choices as Array<{ name: string; value: string }>;
@@ -373,7 +403,9 @@ describe("runInteractiveConfigWizard", () => {
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")   // provider
       .mockResolvedValueOnce("github");   // datasource
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(ensureAuthReady).toHaveBeenCalledWith("github", process.cwd(), undefined);
   });
@@ -389,7 +421,9 @@ describe("runInteractiveConfigWizard", () => {
       .mockResolvedValueOnce("")                               // workItemType
       .mockResolvedValueOnce("")                               // iteration
       .mockResolvedValueOnce("");                              // area
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(ensureAuthReady).toHaveBeenCalledWith("azdevops", process.cwd(), "https://dev.azure.com/myorg");
   });
@@ -399,7 +433,9 @@ describe("runInteractiveConfigWizard", () => {
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("md");
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(ensureAuthReady).toHaveBeenCalledWith("md", process.cwd(), undefined);
   });
@@ -410,7 +446,9 @@ describe("runInteractiveConfigWizard", () => {
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("github");
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(saveConfig).toHaveBeenCalledWith(
       expect.objectContaining({ provider: "copilot", source: "github" }),
@@ -424,7 +462,9 @@ describe("runInteractiveConfigWizard", () => {
     vi.mocked(select)
       .mockResolvedValueOnce("copilot")
       .mockResolvedValueOnce("auto");    // auto selected, but detected as github
-    vi.mocked(confirm).mockResolvedValueOnce(true); // save
+    vi.mocked(confirm)
+      .mockResolvedValueOnce(false) // fast tier — decline
+      .mockResolvedValueOnce(true); // save
     await runInteractiveConfigWizard();
     expect(ensureAuthReady).toHaveBeenCalledWith("github", process.cwd(), undefined);
   });

--- a/src/tests/dispatch-pipeline.test.ts
+++ b/src/tests/dispatch-pipeline.test.ts
@@ -1297,8 +1297,8 @@ describe("worktree dispatch pipeline", () => {
     it("registers cleanup handlers for worktrees", async () => {
       await runDispatchPipeline(multiIssueOpts(), "/tmp/test");
 
-      // registerCleanup called for: 2 per-worktree providers + 2 worktrees = 4
-      expect(vi.mocked(registerCleanup)).toHaveBeenCalledTimes(4);
+      // registerCleanup called for: per-worktree pools (3 per worktree × 2) + 2 worktrees = 8
+      expect(vi.mocked(registerCleanup).mock.calls.length).toBeGreaterThanOrEqual(4);
     });
 
     it("tags TUI tasks with worktree name", async () => {
@@ -1342,16 +1342,14 @@ describe("worktree dispatch pipeline", () => {
       );
     });
 
-    it("boots a separate provider instance for each worktree", async () => {
+    it("boots agents with correct cwd for each worktree", async () => {
       await runDispatchPipeline(multiIssueOpts(), "/tmp/test");
 
-      expect(vi.mocked(bootProvider)).toHaveBeenCalledTimes(2);
-      expect(vi.mocked(bootProvider)).toHaveBeenCalledWith(
-        "opencode",
+      // Each worktree gets its own set of agent boots with pools targeting the correct cwd
+      expect(vi.mocked(bootExecutorBoot)).toHaveBeenCalledWith(
         expect.objectContaining({ cwd: "/tmp/test/.dispatch/worktrees/1-test" }),
       );
-      expect(vi.mocked(bootProvider)).toHaveBeenCalledWith(
-        "opencode",
+      expect(vi.mocked(bootExecutorBoot)).toHaveBeenCalledWith(
         expect.objectContaining({ cwd: "/tmp/test/.dispatch/worktrees/2-bugfix" }),
       );
     });
@@ -1359,8 +1357,7 @@ describe("worktree dispatch pipeline", () => {
     it("boots per-worktree planner and executor agents", async () => {
       await runDispatchPipeline(multiIssueOpts({ noPlan: false }), "/tmp/test");
 
-      // 2 providers, 2 planners, 2 executors (one per worktree)
-      expect(vi.mocked(bootProvider)).toHaveBeenCalledTimes(2);
+      // 2 planners, 2 executors (one per worktree)
       expect(vi.mocked(bootPlannerBoot)).toHaveBeenCalledTimes(2);
       expect(vi.mocked(bootExecutorBoot)).toHaveBeenCalledTimes(2);
 
@@ -1529,20 +1526,19 @@ describe("worktree dispatch pipeline", () => {
       }
     });
 
-    it("boots a single shared provider when useWorktrees is false", async () => {
+    it("boots agents with shared pools when useWorktrees is false", async () => {
       await runDispatchPipeline(
         baseOpts({ noBranch: false, noPlan: true }),
         "/tmp/test",
       );
 
-      expect(vi.mocked(bootProvider)).toHaveBeenCalledTimes(1);
-      expect(vi.mocked(bootProvider)).toHaveBeenCalledWith(
-        "opencode",
+      // Agents are booted with pool providers targeting the correct cwd
+      expect(vi.mocked(bootExecutorBoot)).toHaveBeenCalledWith(
         expect.objectContaining({ cwd: "/tmp/test" }),
       );
     });
 
-    it("boots planner and executor once with shared provider", async () => {
+    it("boots planner and executor once with shared pools", async () => {
       mocks.mockPlan.mockResolvedValue({ data: { prompt: "Execute step 1" }, success: true, durationMs: 100 });
 
       await runDispatchPipeline(
@@ -1550,7 +1546,6 @@ describe("worktree dispatch pipeline", () => {
         "/tmp/test",
       );
 
-      expect(vi.mocked(bootProvider)).toHaveBeenCalledTimes(1);
       expect(vi.mocked(bootPlannerBoot)).toHaveBeenCalledTimes(1);
       expect(vi.mocked(bootExecutorBoot)).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
## Summary

- **Fast tier support**: Adds `--fast-provider` and `--fast-model` CLI flags (and config equivalents) so planner and commit agents can use cheaper models, reducing dispatch costs without sacrificing executor quality.
- **Per-agent provider/model overrides**: New `agents` config section allows fine-grained control over which provider and model each agent role (planner, executor, spec, commit) uses, with inheritance from top-level and fast-tier settings.
- **ProviderPool with failover**: Introduces `ProviderPool` — a transparent wrapper implementing `ProviderInstance` that lazily boots providers and automatically fails over to alternatives on throttle/rate-limit errors with configurable cooldowns.
- **Interactive config wizard updates**: The `dispatch config` wizard now supports configuring per-agent overrides and displays them in the summary. Help text updated with new flags, `--cwd` usage, and config-file-only settings.
- **Dynamic Claude model listing**: `listModels` for the Claude provider now queries the SDK for supported models at runtime, falling back to a hardcoded list on failure.