### PR TITLE
feat: add beta publish workflow for release candidates

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -1,0 +1,46 @@
+name: Publish Beta
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "release/*"
+    paths:
+      - package.json
+
+concurrency:
+  group: publish-beta-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write      # OIDC token for npm trusted publishing + provenance
+
+jobs:
+  publish-beta:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - run: npm ci
+
+      - run: npm run typecheck
+
+      - run: npm test
+
+      - name: Set beta version
+        run: |
+          BASE=$(node -p "require('./package.json').version")
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          BETA_VERSION="${BASE}-beta.${SHORT_SHA}"
+          echo "Publishing beta version: $BETA_VERSION"
+          npm version "$BETA_VERSION" --no-git-tag-version
+
+      - run: npm run build
+
+      - name: Publish to npm (beta)
+        run: npm publish --provenance --tag beta

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         id: compare
         run: |
           LOCAL_VERSION=$(node -p "require('./package.json').version")
-          NPM_VERSION=$(npm view @pruddiman/dispatch version 2>/dev/null || echo "0.0.0")
+          NPM_VERSION=$(npm view @pruddiman/dispatch dist-tags.latest 2>/dev/null || echo "0.0.0")
           echo "local=$LOCAL_VERSION npm=$NPM_VERSION"
 
           SHOULD_PUBLISH=$(node -e "

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pruddiman/dispatch",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pruddiman/dispatch",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.63",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pruddiman/dispatch",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "AI agent orchestration CLI — parse markdown task files, dispatch each unit of work to code agents (OpenCode, GitHub Copilot, etc.), and commit results with conventional commits",
   "type": "module",
   "bin": {

--- a/src/__mocks__/@github/copilot-sdk.ts
+++ b/src/__mocks__/@github/copilot-sdk.ts
@@ -1,0 +1,40 @@
+/**
+ * Test stub for @github/copilot-sdk.
+ *
+ * The real package depends on vscode-jsonrpc/node which uses a CJS
+ * require() that cannot be resolved under Vitest's ESM module loader.
+ * This stub satisfies Vite's import analysis during test runs so that
+ * any test file that transitively touches the provider registry does not
+ * fail at module resolution time.
+ */
+
+import { vi } from "vitest";
+
+export class CopilotClient {
+  constructor(_opts?: unknown) {}
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+  async listModels(): Promise<string[]> {
+    return [];
+  }
+  createSession(_opts?: unknown): CopilotSession {
+    return new CopilotSession();
+  }
+}
+
+export class CopilotSession {
+  async sendMessage(_msg: string): Promise<AsyncIterable<AssistantMessageEvent>> {
+    return (async function* () {})();
+  }
+}
+
+export interface AssistantMessageEvent {
+  type: string;
+  message?: { content: string };
+}
+
+export const approveAll = vi.fn();
+
+export function defineTool(_opts: unknown): unknown {
+  return {};
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@openai/codex": path.resolve(__dirname, "src/__mocks__/@openai/codex.ts"),
+      "@github/copilot-sdk": path.resolve(__dirname, "src/__mocks__/@github/copilot-sdk.ts"),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish-beta.yml` to automatically publish a beta build to npm when a commit lands on any `release/*` branch (triggered by `package.json` changes or manual dispatch)
- Prerelease version is derived ephemerally as `{version}-beta.{short-sha}` — never committed
- Publishes to the `beta` dist-tag with OIDC provenance, leaving `latest` untouched
- Fixes `publish.yml` version comparison to use `dist-tags.latest` instead of `version` to avoid comparing against beta versions