### PR TITLE
chore: test beta publish workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "orchestration",
     "dispatch",
     "tasks",
-    "markdown"
+    "markdown",
+    "beta"
   ],
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Triggers the publish-beta workflow by touching package.json on release/v1.5.0.