### PR TITLE
feat: add stdio transport to dispatch mcp (default) with --http opt-in

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -395,8 +395,9 @@ async function main() {
       .helpOption(false)
       .allowUnknownOption(true)
       .allowExcessArguments(true)
-      .option("--port <number>", "Port to listen on", (v: string) => parseInt(v, 10), 9110)
-      .option("--host <host>", "Host to bind to", "127.0.0.1")
+      .option("--http", "Use HTTP transport instead of stdio (for remote/multi-client use)")
+      .option("--port <number>", "Port to listen on (HTTP mode only)", (v: string) => parseInt(v, 10), 9110)
+      .option("--host <host>", "Host to bind to (HTTP mode only)", "127.0.0.1")
       .option("--cwd <dir>", "Working directory", (v: string) => resolve(v));
 
     try {
@@ -409,15 +410,18 @@ async function main() {
       throw err;
     }
 
-    const mcpOpts = mcpProgram.opts<{ port: number; host: string; cwd?: string }>();
-    const { startMcpServer } = await import("./mcp/index.js");
-    await startMcpServer({
-      port: mcpOpts.port,
-      host: mcpOpts.host,
-      cwd: mcpOpts.cwd ?? process.cwd(),
-    });
-    // startMcpServer installs signal handlers and the http server keeps the
-    // event loop alive; we only reach here if something calls process.exit().
+    const mcpOpts = mcpProgram.opts<{ http?: boolean; port: number; host: string; cwd?: string }>();
+    const cwd = mcpOpts.cwd ?? process.cwd();
+
+    if (mcpOpts.http) {
+      const { startMcpServer } = await import("./mcp/index.js");
+      await startMcpServer({ port: mcpOpts.port, host: mcpOpts.host, cwd });
+    } else {
+      const { startStdioMcpServer } = await import("./mcp/index.js");
+      await startStdioMcpServer({ cwd });
+    }
+    // startMcpServer / startStdioMcpServer install signal handlers and keep
+    // the event loop alive; we only reach here if something calls process.exit().
     return;
   }
 

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,12 +1,12 @@
 /**
  * Entry point for `dispatch mcp`.
  *
- * Opens the SQLite database, starts the MCP HTTP server, and registers
- * signal handlers for graceful shutdown.
+ * Opens the SQLite database, starts the MCP server (stdio by default, HTTP
+ * when --http is passed), and registers signal handlers for graceful shutdown.
  */
 
 import { openDatabase, closeDatabase } from "./state/database.js";
-import { createMcpServer } from "./server.js";
+import { createMcpServer, createStdioMcpServer } from "./server.js";
 
 export interface McpServerOptions {
   port: number;
@@ -46,4 +46,42 @@ export async function startMcpServer(opts: McpServerOptions): Promise<void> {
   process.on("SIGTERM", () => void shutdown("SIGTERM"));
 
   // Keep the process alive — the HTTP server holds the event loop open.
+}
+
+export interface StdioMcpServerOptions {
+  cwd: string;
+}
+
+export async function startStdioMcpServer(opts: StdioMcpServerOptions): Promise<void> {
+  const { cwd } = opts;
+
+  // Initialise the SQLite database for this working directory.
+  // All status messages go to stderr so stdout stays clean for MCP protocol.
+  openDatabase(cwd);
+
+  const handle = await createStdioMcpServer(cwd);
+
+  process.stderr.write("Dispatch MCP server ready (stdio transport). Press Ctrl+C to stop.\n");
+
+  async function shutdown(signal: string) {
+    process.stderr.write(`\nReceived ${signal}, shutting down MCP server...\n`);
+    try {
+      await handle.close();
+    } catch (err) {
+      process.stderr.write(`[dispatch-mcp] Error during server close: ${String(err)}\n`);
+    }
+    try {
+      closeDatabase();
+    } catch (err) {
+      process.stderr.write(`[dispatch-mcp] Error closing database: ${String(err)}\n`);
+    }
+    process.exit(0);
+  }
+
+  // Fire-and-forget: signal handlers are intentionally not awaited — the
+  // shutdown() function calls process.exit(0) itself when done.
+  process.on("SIGINT", () => void shutdown("SIGINT"));
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+
+  // Keep the process alive — the StdioServerTransport holds stdin open.
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,6 +10,7 @@
 import http from "node:http";
 import { randomUUID } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { registerSpecTools } from "./tools/spec.js";
 import { registerDispatchTools } from "./tools/dispatch.js";
@@ -21,6 +22,47 @@ import { addLogCallback } from "./state/manager.js";
 export interface McpServerHandle {
   httpServer: http.Server;
   close(): Promise<void>;
+}
+
+export interface StdioMcpServerHandle {
+  close(): Promise<void>;
+}
+
+/**
+ * Create and return a running MCP stdio server.
+ *
+ * Reads JSON-RPC messages from stdin and writes responses to stdout.
+ * All diagnostic output is written to stderr so it does not corrupt the
+ * MCP protocol stream.
+ *
+ * @param cwd  Working directory for Dispatch commands
+ */
+export async function createStdioMcpServer(cwd: string): Promise<StdioMcpServerHandle> {
+  const mcpServer = new McpServer(
+    { name: "dispatch", version: "1.0.0" },
+    { capabilities: { logging: {} } },
+  );
+
+  // Register all tool groups
+  registerSpecTools(mcpServer, cwd);
+  registerDispatchTools(mcpServer, cwd);
+  registerMonitorTools(mcpServer, cwd);
+  registerRecoveryTools(mcpServer, cwd);
+  registerConfigTools(mcpServer, cwd);
+
+  const transport = new StdioServerTransport();
+  await mcpServer.connect(transport);
+
+  return {
+    close: async () => {
+      await transport.close().catch((err: unknown) => {
+        process.stderr.write(`[dispatch-mcp] transport.close error: ${String(err)}\n`);
+      });
+      await mcpServer.close().catch((err: unknown) => {
+        process.stderr.write(`[dispatch-mcp] mcpServer.close error: ${String(err)}\n`);
+      });
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Switches `dispatch mcp` to use **stdio transport** by default, making it work with local AI agents (Claude Code, Cursor, etc.) that spawn the process and communicate over stdin/stdout
- Adds `--http` flag to opt into the previous HTTP transport (`StreamableHTTPServerTransport` on port 9110) for remote/multi-client scenarios
- All diagnostic output in stdio mode is routed to `stderr` so the MCP protocol stream on `stdout` is not corrupted

## Changes

- `src/mcp/server.ts`: Added `createStdioMcpServer(cwd)` using `StdioServerTransport` alongside the existing `createMcpServer()` HTTP function
- `src/mcp/index.ts`: Added `startStdioMcpServer()` entry point with stderr-only logging; kept `startMcpServer()` for HTTP mode
- `src/cli.ts`: `dispatch mcp` now defaults to stdio; added `--http` flag to use HTTP transport

## Usage

```bash
# Default: stdio (for Claude Code, Cursor, etc.)
dispatch mcp

# HTTP mode (legacy / remote use)
dispatch mcp --http --port 9110
```

MCP client config:
```json
{
  "mcpServers": {
    "dispatch": {
      "command": "dispatch",
      "args": ["mcp", "--cwd", "/path/to/your/project"]
    }
  }
}
```