### PR TITLE
fix: worktree validation and retry for parallel reliability (Bugs 8+9)

### DIFF
--- a/src/helpers/worktree.ts
+++ b/src/helpers/worktree.ts
@@ -11,6 +11,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
+import { rm } from "node:fs/promises";
 import { slugify } from "./slugify.js";
 import { log } from "./logger.js";
 
@@ -62,46 +63,92 @@ export async function createWorktree(
   const worktreePath = join(repoRoot, WORKTREE_DIR, name);
 
   if (existsSync(worktreePath)) {
-    log.debug(`Reusing existing worktree at ${worktreePath}`);
-    return worktreePath;
+    try {
+      const listOutput = await git(["worktree", "list", "--porcelain"], repoRoot);
+      const isRegistered = listOutput.includes(`worktree ${worktreePath}\n`);
+      if (isRegistered) {
+        // Reset to clean state
+        try {
+          await git(["checkout", "--force", branchName], worktreePath);
+          await git(["clean", "-fd"], worktreePath);
+          log.debug(`Reusing validated worktree at ${worktreePath}`);
+          return worktreePath;
+        } catch {
+          // Checkout failed (wrong branch, etc.) — remove and recreate
+          log.debug(`Worktree checkout failed, removing and recreating: ${worktreePath}`);
+        }
+      } else {
+        log.debug(`Directory exists but not a registered worktree: ${worktreePath}`);
+      }
+    } catch {
+      log.debug(`Worktree validation failed for ${worktreePath}`);
+    }
+    // Remove stale directory and fall through to creation
+    await rm(worktreePath, { recursive: true, force: true });
+    // Also prune to clean up any stale git refs
+    await git(["worktree", "prune"], repoRoot).catch(() => {});
   }
 
-  try {
-    const args = ["worktree", "add", worktreePath, "-b", branchName];
-    if (startPoint) args.push(startPoint);
-    await git(args, repoRoot);
-    log.debug(`Created worktree at ${worktreePath} on branch ${branchName}`);
-  } catch (err) {
-    const message = log.extractMessage(err);
-    if (message.includes("already exists")) {
-      // Branch already exists — retry without -b to use the existing branch.
-      // If this also fails (e.g. worktree path conflict), fall through to
-      // prune-and-retry before giving up.
-      try {
-        await git(["worktree", "add", worktreePath, branchName], repoRoot);
-        log.debug(`Created worktree at ${worktreePath} using existing branch ${branchName}`);
-        return worktreePath;
-      } catch (retryErr) {
-        const retryMsg = log.extractMessage(retryErr);
-        if (retryMsg.includes("already used by worktree")) {
-          await git(["worktree", "prune"], repoRoot);
+  const MAX_RETRIES = 5;
+  const BASE_DELAY_MS = 200;
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const args = ["worktree", "add", worktreePath, "-b", branchName];
+      if (startPoint) args.push(startPoint);
+      await git(args, repoRoot);
+      log.debug(`Created worktree at ${worktreePath} on branch ${branchName}`);
+      return worktreePath;
+    } catch (err) {
+      lastError = err;
+      const message = log.extractMessage(err);
+
+      // Handle "branch already exists" — retry without -b
+      if (message.includes("already exists")) {
+        try {
+          await git(["worktree", "add", worktreePath, branchName], repoRoot);
+          log.debug(`Created worktree at ${worktreePath} using existing branch ${branchName}`);
+          return worktreePath;
+        } catch (retryErr) {
+          lastError = retryErr;
+          const retryMsg = log.extractMessage(retryErr);
+          if (retryMsg.includes("already used by worktree")) {
+            await git(["worktree", "prune"], repoRoot);
+            try {
+              await git(["worktree", "add", worktreePath, branchName], repoRoot);
+              log.debug(`Created worktree at ${worktreePath} after pruning stale ref`);
+              return worktreePath;
+            } catch (pruneRetryErr) {
+              lastError = pruneRetryErr;
+            }
+          }
+        }
+      } else if (message.includes("already used by worktree")) {
+        await git(["worktree", "prune"], repoRoot);
+        try {
           await git(["worktree", "add", worktreePath, branchName], repoRoot);
           log.debug(`Created worktree at ${worktreePath} after pruning stale ref`);
-        } else {
-          throw retryErr;
+          return worktreePath;
+        } catch (pruneRetryErr) {
+          lastError = pruneRetryErr;
         }
+      } else if (!message.includes("lock") && !message.includes("already")) {
+        // Non-retryable error — throw immediately
+        throw err;
       }
-    } else if (message.includes("already used by worktree")) {
-      // Branch is locked to a stale worktree ref — prune and retry
-      await git(["worktree", "prune"], repoRoot);
-      await git(["worktree", "add", worktreePath, branchName], repoRoot);
-      log.debug(`Created worktree at ${worktreePath} after pruning stale ref`);
-    } else {
-      throw err;
+
+      // Retryable error (lock contention, race condition) — backoff and retry
+      if (attempt < MAX_RETRIES) {
+        const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1);
+        log.debug(`Worktree creation attempt ${attempt}/${MAX_RETRIES} failed (${message}), retrying in ${delay}ms...`);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
     }
   }
 
-  return worktreePath;
+  throw lastError;
 }
 
 /**

--- a/src/tests/worktree.test.ts
+++ b/src/tests/worktree.test.ts
@@ -5,9 +5,10 @@ const SHELL = process.platform === "win32";
 
 // ─── Mock setup ────────────────────────────────────────────────────────────────
 
-const { mockExecFile, mockExistsSync } = vi.hoisted(() => ({
+const { mockExecFile, mockExistsSync, mockRm } = vi.hoisted(() => ({
   mockExecFile: vi.fn(),
   mockExistsSync: vi.fn(),
+  mockRm: vi.fn(),
 }));
 
 vi.mock("node:child_process", () => ({
@@ -16,6 +17,10 @@ vi.mock("node:child_process", () => ({
 
 vi.mock("node:fs", () => ({
   existsSync: mockExistsSync,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  rm: mockRm,
 }));
 
 vi.mock("node:util", () => ({
@@ -49,7 +54,9 @@ import {
 beforeEach(() => {
   mockExecFile.mockReset();
   mockExistsSync.mockReset();
+  mockRm.mockReset();
   mockExistsSync.mockReturnValue(false);
+  mockRm.mockResolvedValue(undefined);
   vi.mocked(log.warn).mockClear();
   vi.mocked(log.debug).mockClear();
 });
@@ -139,18 +146,98 @@ describe("createWorktree", () => {
     expect(result).toBe(join("/repo", ".dispatch", "worktrees", "issue-42"));
   });
 
-  it("reuses an existing worktree instead of recreating it", async () => {
+  it("validates and reuses a registered worktree on correct branch", async () => {
     const worktreePath = join("/repo", ".dispatch", "worktrees", "issue-42");
     mockExistsSync.mockReturnValue(true);
 
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: `worktree ${worktreePath}\nHEAD abc123\nbranch refs/heads/user/dispatch/42-my-feature\n` }) // worktree list --porcelain
+      .mockResolvedValueOnce({ stdout: "" }) // checkout --force
+      .mockResolvedValueOnce({ stdout: "" }); // clean -fd
+
     const result = await createWorktree("/repo", "42-my-feature.md", "user/dispatch/42-my-feature");
 
-    // No git commands should be called — just returns the existing path
-    expect(mockExecFile).not.toHaveBeenCalled();
-    expect(log.debug).toHaveBeenCalledWith(
-      `Reusing existing worktree at ${worktreePath}`,
-    );
+    expect(mockExecFile).toHaveBeenCalledTimes(3);
+    expect(mockExecFile).toHaveBeenNthCalledWith(1, "git", ["worktree", "list", "--porcelain"], { cwd: "/repo", shell: SHELL });
+    expect(mockExecFile).toHaveBeenNthCalledWith(2, "git", ["checkout", "--force", "user/dispatch/42-my-feature"], { cwd: worktreePath, shell: SHELL });
+    expect(mockExecFile).toHaveBeenNthCalledWith(3, "git", ["clean", "-fd"], { cwd: worktreePath, shell: SHELL });
+    expect(log.debug).toHaveBeenCalledWith(`Reusing validated worktree at ${worktreePath}`);
     expect(result).toBe(worktreePath);
+  });
+
+  it("removes stale directory (not registered) and recreates worktree", async () => {
+    const worktreePath = join("/repo", ".dispatch", "worktrees", "issue-42");
+    mockExistsSync.mockReturnValue(true);
+
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: "worktree /some/other/path\nHEAD abc123\n" }) // list does NOT include worktreePath
+      .mockResolvedValueOnce({ stdout: "" }) // worktree prune (from cleanup)
+      .mockResolvedValueOnce({ stdout: "" }); // worktree add -b
+
+    const result = await createWorktree("/repo", "42-my-feature.md", "user/dispatch/42-my-feature");
+
+    expect(mockRm).toHaveBeenCalledWith(worktreePath, { recursive: true, force: true });
+    expect(log.debug).toHaveBeenCalledWith(`Directory exists but not a registered worktree: ${worktreePath}`);
+    expect(result).toBe(worktreePath);
+  });
+
+  it("removes registered worktree when checkout fails and recreates", async () => {
+    const worktreePath = join("/repo", ".dispatch", "worktrees", "issue-42");
+    mockExistsSync.mockReturnValue(true);
+
+    mockExecFile
+      .mockResolvedValueOnce({ stdout: `worktree ${worktreePath}\nHEAD abc123\n` }) // list includes path
+      .mockRejectedValueOnce(new Error("error: pathspec 'wrong-branch' did not match")) // checkout --force fails
+      .mockResolvedValueOnce({ stdout: "" }) // worktree prune (from cleanup)
+      .mockResolvedValueOnce({ stdout: "" }); // worktree add -b
+
+    const result = await createWorktree("/repo", "42-my-feature.md", "user/dispatch/42-my-feature");
+
+    expect(mockRm).toHaveBeenCalledWith(worktreePath, { recursive: true, force: true });
+    expect(log.debug).toHaveBeenCalledWith(`Worktree checkout failed, removing and recreating: ${worktreePath}`);
+    expect(result).toBe(worktreePath);
+  });
+
+  it("retries on lock contention with exponential backoff", async () => {
+    mockExistsSync.mockReturnValue(false);
+
+    mockExecFile
+      .mockRejectedValueOnce(new Error("fatal: Unable to create '.git/worktrees/issue-42/lock': File exists"))
+      .mockRejectedValueOnce(new Error("fatal: Unable to create '.git/worktrees/issue-42/lock': File exists"))
+      .mockResolvedValueOnce({ stdout: "" }); // succeeds on 3rd attempt
+
+    const result = await createWorktree("/repo", "42-my-feature.md", "user/dispatch/42-my-feature");
+
+    expect(mockExecFile).toHaveBeenCalledTimes(3);
+    expect(log.debug).toHaveBeenCalledWith(expect.stringContaining("attempt 1/5 failed"));
+    expect(log.debug).toHaveBeenCalledWith(expect.stringContaining("attempt 2/5 failed"));
+    expect(result).toBe(join("/repo", ".dispatch", "worktrees", "issue-42"));
+  });
+
+  it("throws immediately on non-retryable errors", async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockExecFile.mockRejectedValueOnce(new Error("fatal: not a git repository"));
+
+    await expect(
+      createWorktree("/repo", "42-my-feature.md", "user/dispatch/42-my-feature"),
+    ).rejects.toThrow("not a git repository");
+
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws last error after max retries exhausted", async () => {
+    mockExistsSync.mockReturnValue(false);
+
+    const lockError = new Error("fatal: Unable to create lock");
+    for (let i = 0; i < 5; i++) {
+      mockExecFile.mockRejectedValueOnce(lockError);
+    }
+
+    await expect(
+      createWorktree("/repo", "42-my-feature.md", "user/dispatch/42-my-feature"),
+    ).rejects.toThrow("lock");
+
+    expect(mockExecFile).toHaveBeenCalledTimes(5);
   });
 
   it("retries without -b when branch already exists and directory does not", async () => {


### PR DESCRIPTION
## Summary
- Validates existing worktree directories before reuse — checks `git worktree list --porcelain` registration, resets to clean state or removes orphaned directories
- Adds exponential-backoff retry (5 attempts, 200ms base) for `git worktree add` to handle lock contention during parallel dispatch
- Non-retryable errors (e.g., "not a git repository") still throw immediately
- Precise porcelain format matching prevents false-positive path collisions (e.g., `issue-4` vs `issue-42`)

## Test plan
- [x] 34 worktree tests pass including 6 new tests for validation, retry, and error handling
- [ ] Manual: dispatch with concurrency > 1 to verify parallel worktree creation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)