### PR TITLE
fix: load config in MCP tools + long-poll status support

### DIFF
--- a/src/mcp/state/manager.ts
+++ b/src/mcp/state/manager.ts
@@ -34,15 +34,22 @@ export type LogCallback = (message: string, level?: "info" | "warn" | "error") =
 interface LiveRun {
   runId: string;
   callbacks: LogCallback[];
+  completionCallbacks: Array<() => void>;
 }
 
 const liveRuns = new Map<string, LiveRun>();
 
 export function registerLiveRun(runId: string): void {
-  liveRuns.set(runId, { runId, callbacks: [] });
+  liveRuns.set(runId, { runId, callbacks: [], completionCallbacks: [] });
 }
 
 export function unregisterLiveRun(runId: string): void {
+  const run = liveRuns.get(runId);
+  if (run) {
+    for (const cb of run.completionCallbacks) {
+      try { cb(); } catch { /* swallow */ }
+    }
+  }
   liveRuns.delete(runId);
 }
 
@@ -65,6 +72,76 @@ export function emitLog(runId: string, message: string, level: "info" | "warn" |
       }
     }
   }
+}
+
+/** Check whether a run is currently registered as live (in-flight). */
+export function isLiveRun(runId: string): boolean {
+  return liveRuns.has(runId);
+}
+
+/** Register a callback that fires when unregisterLiveRun is called for this run. */
+export function addCompletionCallback(runId: string, cb: () => void): void {
+  const run = liveRuns.get(runId);
+  if (run) {
+    run.completionCallbacks.push(cb);
+  }
+}
+
+/**
+ * Wait for a run to leave the "running" state.
+ *
+ * 1. Checks DB immediately — if already terminal, returns true.
+ * 2. If live, registers a completion callback for instant wakeup.
+ * 3. Polls DB every 2s as safety net (race conditions, orphaned runs).
+ * 4. Times out after waitMs (capped at 120s), returning false.
+ */
+export function waitForRunCompletion(
+  runId: string,
+  waitMs: number,
+  getStatus: () => string | null,
+): Promise<boolean> {
+  const effectiveWait = Math.min(Math.max(waitMs, 0), 120_000);
+  if (effectiveWait <= 0) return Promise.resolve(false);
+
+  // Immediate check
+  const currentStatus = getStatus();
+  if (currentStatus !== null && currentStatus !== "running") {
+    return Promise.resolve(true);
+  }
+
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    let pollTimer: ReturnType<typeof setInterval> | undefined;
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      if (pollTimer) clearInterval(pollTimer);
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+    };
+
+    const settle = (completed: boolean) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(completed);
+    };
+
+    // Event-driven wakeup via completion callback
+    if (isLiveRun(runId)) {
+      addCompletionCallback(runId, () => settle(true));
+    }
+
+    // DB poll safety net (every 2s)
+    pollTimer = setInterval(() => {
+      const s = getStatus();
+      if (s !== null && s !== "running") {
+        settle(true);
+      }
+    }, 2_000);
+
+    // Overall timeout
+    timeoutTimer = setTimeout(() => settle(false), effectiveWait);
+  });
 }
 
 // ── Status field runtime validators ──────────────────────────

--- a/src/mcp/tools/_resolve-config.ts
+++ b/src/mcp/tools/_resolve-config.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared config resolution for MCP tools.
+ *
+ * Loads `.dispatch/config.json` and returns the config. Throws if the
+ * config file is missing or has no provider configured — MCP tools
+ * require explicit configuration (unlike the CLI which has an
+ * interactive wizard fallback).
+ */
+
+import { join } from "node:path";
+import { loadConfig, type DispatchConfig } from "../../config.js";
+import { detectDatasource } from "../../datasources/index.js";
+
+/**
+ * Load and validate the Dispatch config for MCP tool use.
+ *
+ * - Throws if no provider is configured (neither in config nor passed by caller).
+ * - Auto-detects datasource from git remote when not configured.
+ */
+export async function loadMcpConfig(
+  cwd: string,
+  overrides?: { provider?: string; source?: string },
+): Promise<DispatchConfig> {
+  const config = await loadConfig(join(cwd, ".dispatch"));
+
+  // Provider must be configured (config file or caller override)
+  const provider = overrides?.provider ?? config.provider;
+  if (!provider) {
+    throw new Error(
+      "Missing required configuration: provider. Run 'dispatch config' to set up defaults.",
+    );
+  }
+
+  // Source: caller override > config > auto-detect from git remote
+  let source = overrides?.source ?? config.source;
+  if (!source) {
+    const detected = await detectDatasource(cwd);
+    if (detected) {
+      source = detected;
+    }
+  }
+
+  return { ...config, provider: provider as DispatchConfig["provider"], source: source as DispatchConfig["source"] };
+}

--- a/src/mcp/tools/dispatch.ts
+++ b/src/mcp/tools/dispatch.ts
@@ -9,6 +9,7 @@ import { createRun } from "../state/manager.js";
 import { PROVIDER_NAMES } from "../../providers/interface.js";
 import { DATASOURCE_NAMES } from "../../datasources/interface.js";
 import { forkDispatchRun } from "./_fork-run.js";
+import { loadMcpConfig } from "./_resolve-config.js";
 
 export function registerDispatchTools(server: McpServer, cwd: string): void {
   // ── dispatch_run ──────────────────────────────────────────────
@@ -17,8 +18,8 @@ export function registerDispatchTools(server: McpServer, cwd: string): void {
     "Execute dispatch pipeline for one or more issue IDs. Returns a runId immediately; progress is pushed via logging notifications.",
     {
       issueIds: z.array(z.string()).min(1).describe("Issue IDs to dispatch (e.g. ['42', '43'])"),
-      provider: z.enum(PROVIDER_NAMES).optional().describe("Agent provider (default: opencode)"),
-      source: z.enum(DATASOURCE_NAMES).optional().describe("Issue datasource: github, azdevops, md"),
+      provider: z.enum(PROVIDER_NAMES).optional().describe("Agent provider (default: from config)"),
+      source: z.enum(DATASOURCE_NAMES).optional().describe("Issue datasource: github, azdevops, md (default: from config)"),
       concurrency: z.number().int().min(1).max(32).optional().describe("Max parallel tasks"),
       noPlan: z.boolean().optional().describe("Skip the planner agent"),
       noBranch: z.boolean().optional().describe("Skip branch creation and PR lifecycle"),
@@ -26,6 +27,16 @@ export function registerDispatchTools(server: McpServer, cwd: string): void {
       retries: z.number().int().min(0).max(10).optional().describe("Retry attempts per task"),
     },
     async (args) => {
+      let config;
+      try {
+        config = await loadMcpConfig(cwd, { provider: args.provider, source: args.source });
+      } catch (err) {
+        return {
+          content: [{ type: "text", text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+          isError: true,
+        };
+      }
+
       const runId = createRun({ cwd, issueIds: args.issueIds });
 
       forkDispatchRun(runId, server, {
@@ -34,9 +45,20 @@ export function registerDispatchTools(server: McpServer, cwd: string): void {
         opts: {
           issueIds: args.issueIds,
           dryRun: false,
-          provider: args.provider ?? "opencode",
-          source: args.source,
-          concurrency: args.concurrency ?? 1,
+          provider: config.provider,
+          model: config.model,
+          fastProvider: config.fastProvider,
+          fastModel: config.fastModel,
+          agents: config.agents,
+          source: config.source,
+          org: config.org,
+          project: config.project,
+          workItemType: config.workItemType,
+          iteration: config.iteration,
+          area: config.area,
+          username: config.username,
+          planTimeout: config.planTimeout,
+          concurrency: args.concurrency ?? config.concurrency ?? 1,
           noPlan: args.noPlan,
           noBranch: args.noBranch,
           noWorktree: args.noWorktree,
@@ -56,15 +78,28 @@ export function registerDispatchTools(server: McpServer, cwd: string): void {
     "Preview tasks that would be dispatched for the given issue IDs without executing anything.",
     {
       issueIds: z.array(z.string()).min(1).describe("Issue IDs to preview"),
-      source: z.enum(DATASOURCE_NAMES).optional().describe("Issue datasource: github, azdevops, md"),
+      source: z.enum(DATASOURCE_NAMES).optional().describe("Issue datasource: github, azdevops, md (default: from config)"),
     },
     async (args) => {
       try {
+        const config = await loadMcpConfig(cwd, { source: args.source });
         const orchestrator = await bootOrchestrator({ cwd });
         const result = await orchestrator.orchestrate({
           issueIds: args.issueIds,
           dryRun: true,
-          source: args.source,
+          provider: config.provider,
+          model: config.model,
+          fastProvider: config.fastProvider,
+          fastModel: config.fastModel,
+          agents: config.agents,
+          source: config.source,
+          org: config.org,
+          project: config.project,
+          workItemType: config.workItemType,
+          iteration: config.iteration,
+          area: config.area,
+          username: config.username,
+          planTimeout: config.planTimeout,
         });
         return {
           content: [{ type: "text", text: JSON.stringify(result) }],

--- a/src/mcp/tools/monitor.ts
+++ b/src/mcp/tools/monitor.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { join } from "node:path";
 import { readdir } from "node:fs/promises";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getRun, listRuns, getTasksForRun, listRunsByStatus } from "../state/manager.js";
+import { getRun, listRuns, getTasksForRun, listRunsByStatus, waitForRunCompletion } from "../state/manager.js";
 import { getDatasource } from "../../datasources/index.js";
 import { loadConfig } from "../../config.js";
 import { DATASOURCE_NAMES } from "../../datasources/interface.js";
@@ -15,22 +15,41 @@ export function registerMonitorTools(server: McpServer, cwd: string): void {
   // ── status_get ────────────────────────────────────────────────
   server.tool(
     "status_get",
-    "Get the current status of a dispatch or spec run, including per-task details.",
+    "Get the current status of a dispatch or spec run, including per-task details. Use waitMs to hold the response until the run completes or the timeout elapses.",
     {
       runId: z.string().describe("The runId returned by dispatch_run or spec_generate"),
+      waitMs: z.number().int().min(0).max(120000).optional().default(0)
+        .describe("Hold response until run completes or timeout (ms). 0 = return immediately."),
     },
     async (args) => {
       try {
-        const run = getRun(args.runId);
+        let run = getRun(args.runId);
         if (!run) {
           return {
             content: [{ type: "text", text: `Run ${args.runId} not found` }],
             isError: true,
           };
         }
+
+        // Long-poll if requested and still running
+        if (run.status === "running" && args.waitMs > 0) {
+          const completed = await waitForRunCompletion(
+            args.runId,
+            args.waitMs,
+            () => getRun(args.runId)?.status ?? null,
+          );
+          if (completed) {
+            run = getRun(args.runId)!;
+          }
+        }
+
         const tasks = getTasksForRun(args.runId);
+        const response: Record<string, unknown> = { run, tasks };
+        if (run.status === "running") {
+          response.retryAfterMs = 5000;
+        }
         return {
-          content: [{ type: "text", text: JSON.stringify({ run, tasks }) }],
+          content: [{ type: "text", text: JSON.stringify(response) }],
         };
       } catch (err) {
         return {

--- a/src/mcp/tools/recovery.ts
+++ b/src/mcp/tools/recovery.ts
@@ -8,10 +8,9 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getRun, getTasksForRun, createRun } from "../state/manager.js";
-import { loadConfig } from "../../config.js";
-import { join } from "node:path";
 import { PROVIDER_NAMES } from "../../providers/interface.js";
 import { forkDispatchRun } from "./_fork-run.js";
+import { loadMcpConfig } from "./_resolve-config.js";
 
 const issueIdsSchema = z.array(z.string());
 
@@ -46,7 +45,16 @@ export function registerRecoveryTools(server: McpServer, cwd: string): void {
         };
       }
 
-      const config = await loadConfig(join(cwd, ".dispatch"));
+      let config;
+      try {
+        config = await loadMcpConfig(cwd, { provider: args.provider });
+      } catch (err) {
+        return {
+          content: [{ type: "text", text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+          isError: true,
+        };
+      }
+
       const issueIds = issueIdsSchema.parse(JSON.parse(originalRun.issueIds));
       const newRunId = createRun({ cwd, issueIds });
 
@@ -56,8 +64,19 @@ export function registerRecoveryTools(server: McpServer, cwd: string): void {
         opts: {
           issueIds,
           dryRun: false,
-          provider: args.provider ?? config.provider ?? "opencode",
+          provider: config.provider,
+          model: config.model,
+          fastProvider: config.fastProvider,
+          fastModel: config.fastModel,
+          agents: config.agents,
           source: config.source,
+          org: config.org,
+          project: config.project,
+          workItemType: config.workItemType,
+          iteration: config.iteration,
+          area: config.area,
+          username: config.username,
+          planTimeout: config.planTimeout,
           concurrency: args.concurrency ?? config.concurrency ?? 1,
           force: true,
         },
@@ -96,7 +115,16 @@ export function registerRecoveryTools(server: McpServer, cwd: string): void {
         };
       }
 
-      const config = await loadConfig(join(cwd, ".dispatch"));
+      let config;
+      try {
+        config = await loadMcpConfig(cwd, { provider: args.provider });
+      } catch (err) {
+        return {
+          content: [{ type: "text", text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+          isError: true,
+        };
+      }
+
       const issueIds = issueIdsSchema.parse(JSON.parse(originalRun.issueIds));
       const newRunId = createRun({ cwd, issueIds });
 
@@ -106,8 +134,19 @@ export function registerRecoveryTools(server: McpServer, cwd: string): void {
         opts: {
           issueIds,
           dryRun: false,
-          provider: args.provider ?? config.provider ?? "opencode",
+          provider: config.provider,
+          model: config.model,
+          fastProvider: config.fastProvider,
+          fastModel: config.fastModel,
+          agents: config.agents,
           source: config.source,
+          org: config.org,
+          project: config.project,
+          workItemType: config.workItemType,
+          iteration: config.iteration,
+          area: config.area,
+          username: config.username,
+          planTimeout: config.planTimeout,
           concurrency: 1,
           force: true,
         },

--- a/src/mcp/tools/spec.ts
+++ b/src/mcp/tools/spec.ts
@@ -6,10 +6,11 @@ import { z } from "zod";
 import { join, resolve, sep } from "node:path";
 import { readdir, readFile } from "node:fs/promises";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { createSpecRun, finishSpecRun, listSpecRuns, getSpecRun } from "../state/manager.js";
+import { createSpecRun, finishSpecRun, listSpecRuns, getSpecRun, waitForRunCompletion } from "../state/manager.js";
 import { PROVIDER_NAMES } from "../../providers/interface.js";
 import { DATASOURCE_NAMES } from "../../datasources/interface.js";
 import { forkDispatchRun } from "./_fork-run.js";
+import { loadMcpConfig } from "./_resolve-config.js";
 
 export function registerSpecTools(server: McpServer, cwd: string): void {
   // ── spec_generate ─────────────────────────────────────────────
@@ -20,12 +21,22 @@ export function registerSpecTools(server: McpServer, cwd: string): void {
       issues: z.string().describe(
         "Comma-separated issue IDs (e.g. '42,43'), a glob pattern (e.g. 'drafts/*.md'), or an inline description."
       ),
-      provider: z.enum(PROVIDER_NAMES).optional().describe("Agent provider name (default: opencode)"),
-      source: z.enum(DATASOURCE_NAMES).optional().describe("Issue datasource: github, azdevops, md"),
+      provider: z.enum(PROVIDER_NAMES).optional().describe("Agent provider name (default: from config)"),
+      source: z.enum(DATASOURCE_NAMES).optional().describe("Issue datasource: github, azdevops, md (default: from config)"),
       concurrency: z.number().int().min(1).max(32).optional().describe("Max parallel spec generations"),
       dryRun: z.boolean().optional().describe("Preview without generating"),
     },
     async (args) => {
+      let config;
+      try {
+        config = await loadMcpConfig(cwd, { provider: args.provider, source: args.source });
+      } catch (err) {
+        return {
+          content: [{ type: "text", text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+          isError: true,
+        };
+      }
+
       const runId = createSpecRun({ cwd, issues: args.issues });
 
       forkDispatchRun(runId, server, {
@@ -33,9 +44,18 @@ export function registerSpecTools(server: McpServer, cwd: string): void {
         cwd,
         opts: {
           issues: args.issues,
-          provider: args.provider ?? "opencode",
-          issueSource: args.source,
-          concurrency: args.concurrency,
+          provider: config.provider,
+          model: config.model,
+          issueSource: config.source,
+          org: config.org,
+          project: config.project,
+          workItemType: config.workItemType,
+          iteration: config.iteration,
+          area: config.area,
+          concurrency: args.concurrency ?? config.concurrency,
+          specTimeout: config.specTimeout,
+          specWarnTimeout: config.specWarnTimeout,
+          specKillTimeout: config.specKillTimeout,
           dryRun: args.dryRun,
           cwd,
         },
@@ -153,21 +173,40 @@ export function registerSpecTools(server: McpServer, cwd: string): void {
   // ── spec_run_status ───────────────────────────────────────────
   server.tool(
     "spec_run_status",
-    "Get the status of a specific spec generation run.",
+    "Get the status of a specific spec generation run. Use waitMs to hold the response until the run completes or the timeout elapses.",
     {
       runId: z.string().describe("The runId returned by spec_generate"),
+      waitMs: z.number().int().min(0).max(120000).optional().default(0)
+        .describe("Hold response until run completes or timeout (ms). 0 = return immediately."),
     },
     async (args) => {
       try {
-        const run = getSpecRun(args.runId);
+        let run = getSpecRun(args.runId);
         if (!run) {
           return {
             content: [{ type: "text", text: `Run ${args.runId} not found` }],
             isError: true,
           };
         }
+
+        // Long-poll if requested and still running
+        if (run.status === "running" && args.waitMs > 0) {
+          const completed = await waitForRunCompletion(
+            args.runId,
+            args.waitMs,
+            () => getSpecRun(args.runId)?.status ?? null,
+          );
+          if (completed) {
+            run = getSpecRun(args.runId)!;
+          }
+        }
+
+        const response: Record<string, unknown> = { ...run };
+        if (run.status === "running") {
+          response.retryAfterMs = 5000;
+        }
         return {
-          content: [{ type: "text", text: JSON.stringify(run) }],
+          content: [{ type: "text", text: JSON.stringify(response) }],
         };
       } catch (err) {
         return {


### PR DESCRIPTION
## Summary
- **MCP config loading**: All MCP tools (`dispatch_run`, `spec_generate`, `run_retry`, `task_retry`, `dispatch_dry_run`) now load `.dispatch/config.json` and merge the full config (model, fastProvider, fastModel, agents, org, project, username, planTimeout, etc.) into the opts passed to the worker. Errors immediately if no provider is configured.
- **Long-poll status**: Added `waitMs` parameter to `status_get` and `spec_run_status` — holds the response open until the run completes or the timeout elapses, with `retryAfterMs` hint when still running.
- **Completion callbacks**: Added event-driven wakeup via completion callbacks in the live run registry, with 2s DB poll safety net for race conditions.

## Test plan
- [ ] `npm run build` passes
- [ ] MCP `dispatch_run` with no explicit provider/source uses config defaults
- [ ] MCP `dispatch_run` without config file returns error
- [ ] MCP `status_get` with `waitMs: 60000` blocks until run completes
- [ ] MCP `status_get` with `waitMs: 0` returns immediately (backward compat)
- [ ] MCP `spec_run_status` with `waitMs` works the same way
- [ ] Recovery tools (`run_retry`, `task_retry`) pass full config to worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)